### PR TITLE
Cloudflare migration stage 2a: route stateless services through the Worker

### DIFF
--- a/src/services/streamingAvailabilityPro.ts
+++ b/src/services/streamingAvailabilityPro.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from "@/integrations/supabase/client";
+import { api } from "@/lib/api-client";
 import { detectUserRegion } from "@/utils/regionDetection";
 
 export interface StreamingOption {
@@ -115,18 +115,12 @@ export const getStreamingAvailabilityBatch = async (
   }
 
   try {
-    const { data, error } = await supabase.functions.invoke('streaming-availability-pro', {
-      body: {
-        tmdbIds: uncachedIds,
-        country: targetCountry,
-        mode
-      }
+    const response = await api.post<StreamingBatchResponse>('/streaming-availability', {
+      tmdbIds: uncachedIds,
+      country: targetCountry,
+      mode
     });
 
-    if (error) throw error;
-
-    const response = data as StreamingBatchResponse;
-    
     if (!response.success) {
       throw new Error('API call failed');
     }

--- a/src/services/tmdb/config.ts
+++ b/src/services/tmdb/config.ts
@@ -1,26 +1,17 @@
-import { supabase } from "@/integrations/supabase/client";
+import { api } from "@/lib/api-client";
 
 export const TMDB_BASE_URL = "https://api.themoviedb.org/3";
 export const TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w500";
 
 export async function getTMDBApiKey() {
   try {
-    const { data, error } = await supabase.functions.invoke('get-tmdb-key', {
-      method: 'POST',
-    });
-
-    if (error) {
-      console.error('Error fetching TMDB API key:', error);
-      throw error;
+    const { key } = await api.get<{ key: string }>("/keys/tmdb");
+    if (!key) {
+      throw new Error("TMDB API key not found in response");
     }
-
-    if (!data?.TMDB_API_KEY) {
-      throw new Error('TMDB API key not found in response');
-    }
-
-    return data.TMDB_API_KEY;
+    return key;
   } catch (error) {
-    console.error('Failed to get TMDB API key:', error);
+    console.error("Failed to get TMDB API key:", error);
     throw error;
   }
 }

--- a/src/services/youtube.ts
+++ b/src/services/youtube.ts
@@ -1,4 +1,4 @@
-import { supabase } from "@/integrations/supabase/client";
+import { api } from "@/lib/api-client";
 
 interface YouTubeSearchResponse {
   items: Array<{
@@ -14,11 +14,16 @@ interface YouTubeSearchResponse {
 
 export const getMovieTrailer = async (movieTitle: string, year?: string): Promise<string> => {
   try {
-    const { data: { YOUTUBE_API_KEY }, error } = await supabase
-      .functions.invoke('get-youtube-key');
-
-    if (error || !YOUTUBE_API_KEY) {
+    let youtubeApiKey = "";
+    try {
+      const res = await api.get<{ key: string }>("/keys/youtube");
+      youtubeApiKey = res.key;
+    } catch (error) {
       console.error('Error fetching YouTube API key:', error);
+      return '';
+    }
+
+    if (!youtubeApiKey) {
       return '';
     }
 
@@ -26,7 +31,7 @@ export const getMovieTrailer = async (movieTitle: string, year?: string): Promis
     const response = await fetch(
       `https://www.googleapis.com/youtube/v3/search?part=snippet&q=${encodeURIComponent(
         searchQuery
-      )}&type=video&key=${YOUTUBE_API_KEY}&maxResults=1`
+      )}&type=video&key=${youtubeApiKey}&maxResults=1`
     );
 
     if (!response.ok) {


### PR DESCRIPTION
## Cel

Pierwszy, bezpieczny krok etapu 2: przepięcie tych wywołań Supabase, które **nie dotyczą tożsamości użytkownika**, na wdrożony już Worker Cloudflare. Dzięki temu nie wymaga decyzji o migracji kont/danych i da się przetestować na żywym wdrożeniu.

## Zmiany

- `getTMDBApiKey` — funkcja edge `get-tmdb-key` → `GET /api/keys/tmdb`
- `getMovieTrailer` — funkcja edge `get-youtube-key` → `GET /api/keys/youtube`
- `getStreamingAvailabilityBatch` — funkcja edge `streaming-availability-pro` → `POST /api/streaming-availability` (ten sam kontrakt odpowiedzi `{ success, data }`)

## Co zostaje na Supabase (kolejny krok)

- Logowanie (`supabase.auth`) → Better Auth
- Tabele danych użytkownika (`supabase.from(...)`) → Worker/D1
- Funkcje rekomendacji AI i `movie-insights` → port do Workera

Ten krok wymaga decyzji: konta/dane **na czysto** czy **migracja** ze starej bazy (mapowanie ID + reset haseł bcrypt).

## Weryfikacja

- `tsc -b` i `vite build` przechodzą.
- Działa na żywym wdrożeniu, bo Worker (`/api/keys/*`, `/api/streaming-availability`) jest już online z ustawionymi sekretami `TMDB_API_KEY`/`RAPIDAPI_KEY`.

## Wymaga (po stronie konta)

Sekret `YOUTUBE_API_KEY` na Workerze (jeśli zwiastuny mają działać) — `wrangler secret put YOUTUBE_API_KEY`.

https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG)_