### PR TITLE
Cloudflare migration stage 2b: auth + core user data on Better Auth/D1

### DIFF
--- a/src/components/UserStreamingPreferences.tsx
+++ b/src/components/UserStreamingPreferences.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { useToast } from "./ui/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { getStreamingServices, getUserPreferences, setUserPreferences } from "@/services/preferences";
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { ServiceList } from "./streaming/ServiceList";
@@ -20,93 +20,50 @@ export const UserStreamingPreferences = () => {
   }, []);
 
   const fetchStreamingServices = async () => {
-    const { data, error } = await supabase
-      .from('streaming_services')
-      .select('*');
-    
-    if (error) {
+    try {
+      const data = await getStreamingServices();
+      setServices(data);
+    } catch (error) {
       toast({
         variant: "destructive",
         title: "Error Loading Services",
-        description: error.message,
+        description: error instanceof Error ? error.message : "Failed to load services",
       });
-    } else if (data) {
-      setServices(data);
     }
     setIsLoading(false);
   };
 
   const fetchUserPreferences = async () => {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return;
-
-    const { data: preferences, error } = await supabase
-      .from('user_streaming_preferences')
-      .select('service_id')
-      .eq('user_id', user.id);
-    
-    if (error) {
+    try {
+      const preferences = await getUserPreferences();
+      setSelectedServices(preferences);
+    } catch (error) {
       toast({
         variant: "destructive",
         title: "Error Loading Preferences",
-        description: error.message,
+        description: error instanceof Error ? error.message : "Failed to load preferences",
       });
-    } else if (preferences) {
-      setSelectedServices(preferences.map(pref => pref.service_id));
     }
   };
 
   const handleServiceToggle = async (serviceId: string) => {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
+    const isSelected = selectedServices.includes(serviceId);
+    const next = isSelected
+      ? selectedServices.filter(id => id !== serviceId)
+      : [...selectedServices, serviceId];
+
+    try {
+      await setUserPreferences(next);
+    } catch (error) {
       toast({
         variant: "destructive",
-        title: "Authentication Error",
-        description: "You must be logged in to manage streaming preferences",
+        title: "Error Updating Preferences",
+        description: error instanceof Error ? error.message : "You must be logged in to manage streaming preferences",
       });
       return;
     }
 
-    const isSelected = selectedServices.includes(serviceId);
-    
-    if (isSelected) {
-      const { error } = await supabase
-        .from('user_streaming_preferences')
-        .delete()
-        .eq('service_id', serviceId)
-        .eq('user_id', user.id);
-      
-      if (error) {
-        toast({
-          variant: "destructive",
-          title: "Error Removing Service",
-          description: error.message,
-        });
-        return;
-      }
-    } else {
-      const { error } = await supabase
-        .from('user_streaming_preferences')
-        .insert({ 
-          service_id: serviceId,
-          user_id: user.id
-        });
-      
-      if (error) {
-        toast({
-          variant: "destructive",
-          title: "Error Adding Service",
-          description: error.message,
-        });
-        return;
-      }
-    }
-
-    setSelectedServices(prev =>
-      isSelected
-        ? prev.filter(id => id !== serviceId)
-        : [...prev, serviceId]
-    );
+    setSelectedServices(next);
 
     toast({
       title: isSelected ? "Service Removed" : "Service Added",

--- a/src/components/creators/FavoriteCreatorsList.tsx
+++ b/src/components/creators/FavoriteCreatorsList.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useToast } from "@/components/ui/use-toast";
 import { UserPlus, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { supabase } from "@/integrations/supabase/client";
+import { getFavoriteCreators, addFavoriteCreator, removeFavoriteCreator } from "@/services/creators";
 
 interface Creator {
   id: string;
@@ -29,36 +29,17 @@ export const FavoriteCreatorsList = () => {
   const { data: creators, isLoading } = useQuery({
     queryKey: ['favorite-creators'],
     queryFn: async () => {
-      const { data: session } = await supabase.auth.getSession();
-      if (!session.session?.user) throw new Error('Not authenticated');
-
-      const { data, error } = await supabase
-        .from('favorite_creators')
-        .select('*')
-        .eq('user_id', session.session.user.id);
-      
-      if (error) throw error;
-      return data as Creator[];
+      return (await getFavoriteCreators()) as Creator[];
     },
   });
 
   const addCreator = useMutation({
     mutationFn: async (creator: { name: string; role: string }) => {
-      const { data: session } = await supabase.auth.getSession();
-      if (!session.session?.user) throw new Error('Not authenticated');
-
-      const { error } = await supabase
-        .from('favorite_creators')
-        .insert([
-          { 
-            name: creator.name,
-            role: creator.role,
-            tmdb_person_id: 0, // We'll implement TMDB search in a future update
-            user_id: session.session.user.id
-          }
-        ]);
-      
-      if (error) throw error;
+      await addFavoriteCreator({
+        name: creator.name,
+        role: creator.role,
+        tmdb_person_id: 0, // We'll implement TMDB search in a future update
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['favorite-creators'] });
@@ -81,12 +62,7 @@ export const FavoriteCreatorsList = () => {
 
   const removeCreator = useMutation({
     mutationFn: async (id: string) => {
-      const { error } = await supabase
-        .from('favorite_creators')
-        .delete()
-        .eq('id', id);
-      
-      if (error) throw error;
+      await removeFavoriteCreator(id);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['favorite-creators'] });

--- a/src/components/navigation/UserActions.tsx
+++ b/src/components/navigation/UserActions.tsx
@@ -2,7 +2,7 @@
 import { Button } from "@/components/ui/button";
 import { LogOut, Settings } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { supabase } from "@/integrations/supabase/client";
+import { authClient } from "@/lib/auth-client";
 import { useToast } from "@/hooks/use-toast";
 import { useTranslation } from "react-i18next";
 import { ThemeSwitcher } from "../ThemeSwitcher";
@@ -24,7 +24,7 @@ export const UserActions = () => {
 
   const handleLogout = async () => {
     try {
-      const { error } = await supabase.auth.signOut();
+      const { error } = await authClient.signOut();
       if (error) {
         toast({
           variant: "destructive",

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -1,25 +1,30 @@
-import { useEffect, useState } from "react";
-import { Session } from "@supabase/supabase-js";
-import { supabase } from "@/integrations/supabase/client";
+import { authClient } from "@/lib/auth-client";
 
+export interface AppUser {
+  id: string;
+  email: string;
+  name?: string | null;
+  image?: string | null;
+}
+
+/**
+ * Auth hook backed by Better Auth (Cloudflare Worker + D1), replacing
+ * the previous Supabase auth. Keeps the `{ session }` shape so existing
+ * consumers that read `session?.user?.id` keep working.
+ */
 export const useAuth = () => {
-  const [session, setSession] = useState<Session | null>(null);
+  const { data, isPending } = authClient.useSession();
 
-  useEffect(() => {
-    // Get initial session
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session);
-    });
+  const user: AppUser | null = data?.user
+    ? {
+        id: data.user.id,
+        email: data.user.email,
+        name: data.user.name,
+        image: data.user.image ?? null,
+      }
+    : null;
 
-    // Listen for auth changes
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session);
-    });
+  const session = user ? { user } : null;
 
-    return () => subscription.unsubscribe();
-  }, []);
-
-  return { session };
+  return { session, user, isLoading: isPending };
 };

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,8 +1,6 @@
 
 import { useState, useEffect } from "react";
-import { Auth as SupabaseAuth } from "@supabase/auth-ui-react";
-import { ThemeSupa } from "@supabase/auth-ui-shared";
-import { supabase } from "@/integrations/supabase/client";
+import { signIn, signUp } from "@/lib/auth-client";
 import { useAuth } from "@/hooks/use-auth";
 import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
@@ -13,6 +11,32 @@ const Auth = () => {
   const { session } = useAuth();
   const navigate = useNavigate();
   const [showFlash, setShowFlash] = useState(false);
+  const [mode, setMode] = useState<"signin" | "signup">("signin");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const res =
+        mode === "signin"
+          ? await signIn.email({ email, password })
+          : await signUp.email({ email, password, name: name || email.split("@")[0] });
+      if (res.error) {
+        setError(res.error.message || "Authentication failed");
+      }
+      // On success, useSession updates and the effect below navigates home.
+    } catch {
+      setError("Authentication failed");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
     if (session) {
@@ -132,74 +156,72 @@ const Auth = () => {
                 </p>
               </div>
 
-              <SupabaseAuth
-                supabaseClient={supabase}
-                appearance={{
-                  theme: ThemeSupa,
-                  variables: {
-                    default: {
-                      colors: {
-                        brand: "rgb(147, 51, 234)",
-                        brandAccent: "rgb(126, 34, 206)",
-                        inputBackground: "rgba(255,255,255,0.03)",
-                        inputBorder: "rgba(255,255,255,0.1)",
-                        inputText: "white",
-                        inputLabelText: "rgba(255,255,255,0.4)",
-                        inputPlaceholder: "rgba(255,255,255,0.2)",
-                        messageText: "rgb(248, 113, 113)",
-                        anchorTextColor: "rgb(147, 51, 234)",
-                        dividerBackground: "rgba(255,255,255,0.05)",
-                      },
-                      borderWidths: {
-                        buttonBorderWidth: "1px",
-                        inputBorderWidth: "0px",
-                      },
-                      radii: {
-                        borderRadiusButton: "1rem",
-                        buttonBorderRadius: "1rem",
-                        inputBorderRadius: "1rem",
-                      },
-                      space: {
-                        inputPadding: "14px 16px",
-                        buttonPadding: "14px 24px",
-                      },
-                      fonts: {
-                        bodyFontFamily: "'Outfit', sans-serif",
-                        buttonFontFamily: "'Space Grotesk', sans-serif",
-                        inputFontFamily: "'Outfit', sans-serif",
-                        labelFontFamily: "'Outfit', sans-serif",
-                      },
-                      fontSizes: {
-                        baseBodySize: "14px",
-                        baseInputSize: "15px",
-                        baseLabelSize: "12px",
-                        baseButtonSize: "14px",
-                      },
-                    },
-                  },
-                  className: {
-                    button:
-                      "!font-bold !uppercase !tracking-widest !shadow-lg !shadow-purple-500/20 !transition-all hover:!shadow-xl",
-                    container: "!gap-5",
-                    divider: "!opacity-20",
-                    label: "!uppercase !tracking-widest !text-[10px] !font-bold",
-                    input:
-                      "!bg-white/[0.03] !border-b-2 !border-white/10 !rounded-none !rounded-t-xl focus:!border-purple-500 !transition-colors",
-                    message: "!text-red-400 !text-xs",
-                    anchor: "!text-purple-400 !text-xs !font-bold hover:!text-purple-300",
-                  },
-                }}
-                theme="dark"
-                providers={["google"]}
-                redirectTo={window.location.origin}
-              />
+              <form onSubmit={handleSubmit} className="space-y-5">
+                {mode === "signup" && (
+                  <div className="space-y-2">
+                    <label className="block text-[10px] font-bold uppercase tracking-widest text-white/40">
+                      Name
+                    </label>
+                    <input
+                      type="text"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      placeholder="Your name"
+                      className="w-full px-4 py-3.5 rounded-xl bg-white/[0.03] border-b-2 border-white/10 text-white placeholder:text-white/20 focus:border-purple-500 focus:outline-none transition-colors"
+                    />
+                  </div>
+                )}
+                <div className="space-y-2">
+                  <label className="block text-[10px] font-bold uppercase tracking-widest text-white/40">
+                    Email
+                  </label>
+                  <input
+                    type="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="you@example.com"
+                    className="w-full px-4 py-3.5 rounded-xl bg-white/[0.03] border-b-2 border-white/10 text-white placeholder:text-white/20 focus:border-purple-500 focus:outline-none transition-colors"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-[10px] font-bold uppercase tracking-widest text-white/40">
+                    Password
+                  </label>
+                  <input
+                    type="password"
+                    required
+                    minLength={8}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="••••••••"
+                    className="w-full px-4 py-3.5 rounded-xl bg-white/[0.03] border-b-2 border-white/10 text-white placeholder:text-white/20 focus:border-purple-500 focus:outline-none transition-colors"
+                  />
+                </div>
 
-              <p className="text-center text-white/10 text-xs mt-8 font-medium">
-                Forgot password?{" "}
-                <span className="text-white/20 italic">
-                  Contact the projectionist.
-                </span>
-              </p>
+                {error && <p className="text-red-400 text-xs">{error}</p>}
+
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="w-full py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 disabled:opacity-60 text-white font-bold uppercase tracking-widest text-sm shadow-lg shadow-purple-500/20 transition-all active:scale-95"
+                >
+                  {loading ? "Please wait…" : mode === "signin" ? "Sign In" : "Create Account"}
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMode(mode === "signin" ? "signup" : "signin");
+                    setError(null);
+                  }}
+                  className="w-full text-center text-purple-400 hover:text-purple-300 text-xs font-bold"
+                >
+                  {mode === "signin"
+                    ? "Need an account? Sign up"
+                    : "Have an account? Sign in"}
+                </button>
+              </form>
             </div>
           </motion.div>
         </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,7 +5,10 @@ import { Footer } from "@/components/Footer";
 import { MouseGlow } from "@/components/effects/MouseGlow";
 import { useAuth } from "@/hooks/use-auth";
 import { useNavigate } from "react-router-dom";
-import { supabase } from "@/integrations/supabase/client";
+import { authClient } from "@/lib/auth-client";
+import { api } from "@/lib/api-client";
+import { getSavedMovies, type SavedMovie } from "@/services/user";
+import { getWatchedMovies } from "@/services/watched";
 import { motion } from "framer-motion";
 import {
   Film, Clock, Trophy, User, Settings, Sparkles,
@@ -20,7 +23,7 @@ const Dashboard = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
   const [stats, setStats] = useState({ saved: 0, watched: 0, quizzes: 0 });
-  const [recentFavorites, setRecentFavorites] = useState<any[]>([]);
+  const [recentFavorites, setRecentFavorites] = useState<SavedMovie[]>([]);
   const [cinemaMode, setCinemaMode] = useState(false);
   const [audioFeedback, setAudioFeedback] = useState(true);
 
@@ -34,34 +37,27 @@ const Dashboard = () => {
 
   const fetchStats = async () => {
     try {
-      const [savedRes, watchedRes, quizRes] = await Promise.all([
-        supabase.from("saved_movies").select("*", { count: "exact", head: true }).eq("user_id", user!.id),
-        supabase.from("watched_movies").select("*", { count: "exact", head: true }).eq("user_id", user!.id),
-        supabase.from("quiz_history").select("*", { count: "exact", head: true }).eq("user_id", user!.id),
+      const [saved, watched, quizzes] = await Promise.all([
+        getSavedMovies(),
+        getWatchedMovies(),
+        api.get<unknown[]>("/quiz/history").catch(() => [] as unknown[]),
       ]);
 
       setStats({
-        saved: savedRes.count || 0,
-        watched: watchedRes.count || 0,
-        quizzes: quizRes.count || 0,
+        saved: saved.length,
+        watched: watched.length,
+        quizzes: quizzes.length,
       });
 
-      // Fetch recent favorites for activity feed
-      const { data: recent } = await supabase
-        .from("saved_movies")
-        .select("*")
-        .eq("user_id", user!.id)
-        .order("created_at", { ascending: false })
-        .limit(5);
-
-      setRecentFavorites(recent || []);
+      // Recent favorites for activity feed (already ordered newest-first)
+      setRecentFavorites(saved.slice(0, 5));
     } catch (err) {
       console.error("Dashboard stats error:", err);
     }
   };
 
   const handleSignOut = async () => {
-    await supabase.auth.signOut();
+    await authClient.signOut();
     navigate("/");
     toast({ title: "Signed out successfully" });
   };
@@ -71,8 +67,8 @@ const Dashboard = () => {
   if (!user) return null;
 
   const userEmail = user.email || "";
-  const userName = user.user_metadata?.full_name || user.user_metadata?.name || userEmail.split("@")[0];
-  const userAvatar = user.user_metadata?.avatar_url;
+  const userName = user.name || userEmail.split("@")[0];
+  const userAvatar = user.image || undefined;
 
   // Rank based on activity
   const getRank = () => {

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
 import { useAuth } from "@/hooks/use-auth";
-import { supabase } from "@/integrations/supabase/client";
+import { getSavedMovies, removeSavedMovie } from "@/services/user";
 import { MouseGlow } from "@/components/effects/MouseGlow";
 import { FilmGrain } from "@/components/effects/FilmGrain";
 import { EnhancedMovieModal } from "@/components/movie/EnhancedMovieModal";
@@ -39,13 +39,7 @@ const Favorites = () => {
 
   const fetchFavorites = async () => {
     try {
-      const { data, error } = await supabase
-        .from("saved_movies")
-        .select("*")
-        .eq("user_id", user?.id)
-        .order("created_at", { ascending: false });
-
-      if (error) throw error;
+      const data = await getSavedMovies();
 
       const movieData: TMDBMovie[] =
         data?.map((movie) => ({
@@ -76,13 +70,7 @@ const Favorites = () => {
   const handleRemove = async (tmdbId: number, e: React.MouseEvent) => {
     e.stopPropagation();
     try {
-      const { error } = await supabase
-        .from("saved_movies")
-        .delete()
-        .eq("tmdb_id", tmdbId)
-        .eq("user_id", user?.id);
-
-      if (error) throw error;
+      await removeSavedMovie(tmdbId);
       setFavorites((prev) => prev.filter((m) => m.id !== tmdbId));
       toast({ title: "Removed from collection" });
     } catch {

--- a/src/pages/Ratings.tsx
+++ b/src/pages/Ratings.tsx
@@ -1,7 +1,7 @@
 
 import { useState, useEffect } from "react";
 import { useAuth } from "@/hooks/use-auth";
-import { supabase } from "@/integrations/supabase/client";
+import { getRatedMovies } from "@/services/watched";
 import { LoadingState } from "@/components/LoadingState";
 import { EmptyRatings } from "@/components/pages/EmptyRatings";
 import { OptimizedMovieGrid } from "@/components/movie/OptimizedMovieGrid";
@@ -25,14 +25,7 @@ const Ratings = () => {
 
   const fetchRatings = async () => {
     try {
-      const { data, error } = await supabase
-        .from('watched_movies')
-        .select('*')
-        .eq('user_id', user?.id)
-        .not('rating', 'is', null)
-        .order('watched_at', { ascending: false });
-
-      if (error) throw error;
+      const data = await getRatedMovies();
 
       // Convert watched movies to TMDBMovie format
       const movieData: TMDBMovie[] = data?.map(movie => ({

--- a/src/services/creators.ts
+++ b/src/services/creators.ts
@@ -1,4 +1,4 @@
-import { supabase } from "@/integrations/supabase/client";
+import { api, ApiError } from "@/lib/api-client";
 
 export interface Creator {
   id: string;
@@ -12,34 +12,43 @@ export interface CreateCreatorInput {
   name: string;
   role: string;
   tmdb_person_id: number;
-  user_id: string;
+  user_id?: string;
 }
 
-export const addFavoriteCreator = async (creator: CreateCreatorInput) => {
-  const { data, error } = await supabase
-    .from('favorite_creators')
-    .insert([creator])
-    .select()
-    .single();
+interface CreatorRow {
+  id: string;
+  name: string;
+  role: string;
+  tmdbPersonId: number;
+  userId: string;
+}
 
-  if (error) throw error;
-  return data;
+const mapCreator = (r: CreatorRow): Creator => ({
+  id: r.id,
+  name: r.name,
+  role: r.role,
+  tmdb_person_id: r.tmdbPersonId,
+  user_id: r.userId,
+});
+
+export const addFavoriteCreator = async (creator: CreateCreatorInput): Promise<void> => {
+  await api.post("/creators", {
+    name: creator.name,
+    role: creator.role,
+    tmdbPersonId: creator.tmdb_person_id,
+  });
 };
 
-export const removeFavoriteCreator = async (creatorId: string) => {
-  const { error } = await supabase
-    .from('favorite_creators')
-    .delete()
-    .eq('id', creatorId);
-
-  if (error) throw error;
+export const removeFavoriteCreator = async (creatorId: string): Promise<void> => {
+  await api.delete(`/creators/${creatorId}`);
 };
 
-export const getFavoriteCreators = async () => {
-  const { data, error } = await supabase
-    .from('favorite_creators')
-    .select('*');
-
-  if (error) throw error;
-  return data;
+export const getFavoriteCreators = async (): Promise<Creator[]> => {
+  try {
+    const rows = await api.get<CreatorRow[]>("/creators");
+    return rows.map(mapCreator);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) return [];
+    throw error;
+  }
 };

--- a/src/services/preferences.ts
+++ b/src/services/preferences.ts
@@ -1,0 +1,26 @@
+import { api, ApiError } from "@/lib/api-client";
+import type { StreamingService } from "@/types/streaming";
+
+interface ServiceRow {
+  id: string;
+  name: string;
+  logoUrl: string | null;
+}
+
+export const getStreamingServices = async (): Promise<StreamingService[]> => {
+  const rows = await api.get<ServiceRow[]>("/streaming-services");
+  return rows.map((r) => ({ id: r.id, name: r.name, logo_url: r.logoUrl }));
+};
+
+export const getUserPreferences = async (): Promise<string[]> => {
+  try {
+    return await api.get<string[]>("/preferences");
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) return [];
+    throw error;
+  }
+};
+
+export const setUserPreferences = async (services: string[]): Promise<void> => {
+  await api.put("/preferences", { services });
+};

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,57 +1,60 @@
-import { supabase } from "@/integrations/supabase/client";
-import type { Database } from "@/integrations/supabase/types";
+import { api, ApiError } from "@/lib/api-client";
 
-type SavedMovie = Database["public"]["Tables"]["saved_movies"]["Row"];
+export interface SavedMovie {
+  id: string;
+  user_id: string;
+  tmdb_id: number;
+  title: string;
+  poster_path: string | null;
+  created_at: string;
+}
+
+interface SavedRow {
+  id: string;
+  userId: string;
+  tmdbId: number;
+  title: string;
+  posterPath: string | null;
+  createdAt: string;
+}
+
+const mapSaved = (r: SavedRow): SavedMovie => ({
+  id: r.id,
+  user_id: r.userId,
+  tmdb_id: r.tmdbId,
+  title: r.title,
+  poster_path: r.posterPath,
+  created_at: r.createdAt,
+});
 
 export const getSavedMovies = async (): Promise<SavedMovie[]> => {
-  const { data, error } = await supabase
-    .from("saved_movies")
-    .select("*");
-
-  if (error) throw error;
-  return data || [];
+  try {
+    const rows = await api.get<SavedRow[]>("/movies/saved");
+    return rows.map(mapSaved);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) return [];
+    throw error;
+  }
 };
 
-export const saveMovies = async (movies: { tmdb_id: number; title: string; poster_path: string }[]) => {
-  const user = (await supabase.auth.getUser()).data.user;
-  if (!user) throw new Error("User not authenticated");
-
-  const moviesToSave = movies.map(movie => ({
-    ...movie,
-    user_id: user.id,
-  }));
-
-  const { error } = await supabase
-    .from("saved_movies")
-    .insert(moviesToSave);
-
-  if (error) throw error;
+export const saveMovies = async (
+  movies: { tmdb_id: number; title: string; poster_path?: string | null }[]
+): Promise<void> => {
+  // The Worker derives the user from the session cookie.
+  for (const movie of movies) {
+    await api.post("/movies/saved", {
+      tmdbId: movie.tmdb_id,
+      title: movie.title,
+      posterPath: movie.poster_path ?? null,
+    });
+  }
 };
 
-export const removeSavedMovie = async (tmdb_id: number) => {
-  const user = (await supabase.auth.getUser()).data.user;
-  if (!user) throw new Error("User not authenticated");
-
-  const { error } = await supabase
-    .from("saved_movies")
-    .delete()
-    .eq("tmdb_id", tmdb_id)
-    .eq("user_id", user.id);
-
-  if (error) throw error;
+export const removeSavedMovie = async (tmdb_id: number): Promise<void> => {
+  await api.delete(`/movies/saved/${tmdb_id}`);
 };
 
 export const isSavedMovie = async (tmdb_id: number): Promise<boolean> => {
-  const user = (await supabase.auth.getUser()).data.user;
-  if (!user) return false;
-
-  const { data, error } = await supabase
-    .from("saved_movies")
-    .select("id")
-    .eq("tmdb_id", tmdb_id)
-    .eq("user_id", user.id)
-    .single();
-
-  if (error && error.code !== "PGRST116") throw error;
-  return !!data;
+  const saved = await getSavedMovies();
+  return saved.some((m) => m.tmdb_id === tmdb_id);
 };

--- a/src/services/watched.ts
+++ b/src/services/watched.ts
@@ -1,0 +1,62 @@
+import { api, ApiError } from "@/lib/api-client";
+
+export interface WatchedMovie {
+  id: string;
+  user_id: string;
+  tmdb_id: number;
+  title: string;
+  rating: number | null;
+  watched_at: string;
+  created_at: string;
+}
+
+interface WatchedRow {
+  id: string;
+  userId: string;
+  tmdbId: number;
+  title: string;
+  rating: number | null;
+  watchedAt: string;
+  createdAt: string;
+}
+
+const mapWatched = (r: WatchedRow): WatchedMovie => ({
+  id: r.id,
+  user_id: r.userId,
+  tmdb_id: r.tmdbId,
+  title: r.title,
+  rating: r.rating,
+  watched_at: r.watchedAt,
+  created_at: r.createdAt,
+});
+
+export const getWatchedMovies = async (): Promise<WatchedMovie[]> => {
+  try {
+    const rows = await api.get<WatchedRow[]>("/movies/watched");
+    return rows.map(mapWatched);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) return [];
+    throw error;
+  }
+};
+
+export const getRatedMovies = async (): Promise<WatchedMovie[]> => {
+  const watched = await getWatchedMovies();
+  return watched.filter((m) => m.rating != null);
+};
+
+export const addWatchedMovie = async (movie: {
+  tmdb_id: number;
+  title?: string;
+  rating?: number;
+}): Promise<void> => {
+  await api.post("/movies/watched", {
+    tmdbId: movie.tmdb_id,
+    title: movie.title ?? "",
+    rating: movie.rating,
+  });
+};
+
+export const removeWatchedMovie = async (id: string): Promise<void> => {
+  await api.delete(`/movies/watched/${id}`);
+};


### PR DESCRIPTION
## Cel

Wariant **„na czysto"** (bez importu danych): logowanie i funkcje związane z kontem przechodzą w całości na Cloudflare Worker + D1 + Better Auth. Supabase nie jest już używany do auth ani do tych tabel.

> Stack: PR #3 (stage 1) ← PR #4 (stage 2a, stateless) ← **ten PR (stage 2b)**.

## Zmiany

**Auth**
- `use-auth.tsx` opakowuje `useSession` z Better Auth (zachowuje kształt `{ session: { user } }`, więc dotychczasowe `session?.user?.id` działa bez zmian).
- `Auth.tsx` — własny formularz e-mail/hasło (logowanie + rejestracja) zamiast widżetu `@supabase/auth-ui-react`.
- Wylogowanie (`UserActions`, `Dashboard`) przez `authClient.signOut()`.

**Dane** (typowany `api-client` → Worker `/api/*`, z mapowaniem camelCase z D1 na snake_case, którego oczekuje UI)
- `services/user.ts` (ulubione), nowy `services/watched.ts` (obejrzane/oceny), `services/creators.ts`, nowy `services/preferences.ts`.
- `Favorites`, `Ratings`, `Dashboard`, `UserStreamingPreferences`, `FavoriteCreatorsList` korzystają z tych serwisów zamiast `supabase.from(...)`.

## Weryfikacja

Przetestowane end-to-end na `wrangler dev` + lokalne D1:
- rejestracja/logowanie (cookie sesji), CRUD ulubionych, preferencji i twórców, publiczna lista serwisów ✓
- `tsc` i `vite build` przechodzą; brak nowych błędów ESLint ✓

## Wciąż na Supabase (ostatni krok — kolejny PR)

Funkcje rekomendacji AI (`get-enhanced-recommendations`, `get-personalized-recommendations`), zapis historii/grup quizów, kolaboratywny filtering między użytkownikami oraz legacy `movie_lists`/`movie_streaming_availability`. Te ścieżki na razie degradują się łagodnie (brak crashy), bo używają `supabase.auth.getUser()` zwracającego teraz null.

## Uwaga bezpieczeństwa (nadal aktualna)

Rotacja wykradzionych kluczy z `.env` (service_role Supabase, RapidAPI) — do zrobienia po Twojej stronie. Czyszczenie historii gita zrobię na wyraźne „tak", po rotacji.

https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG)_