### PR TITLE
Streaming accuracy: authoritative region from the Cloudflare edge

### DIFF
--- a/src/lib/region-bootstrap.ts
+++ b/src/lib/region-bootstrap.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve the user's real country from the Cloudflare edge once per load
+ * and cache it (cf-region) for synchronous region detection.
+ *
+ * A manual choice (user-region) always wins, so we skip when it is set.
+ * Best-effort and non-blocking: on a non-Cloudflare host or when offline
+ * this silently no-ops and detection falls back to locale/timezone.
+ */
+export async function bootstrapRegion(): Promise<void> {
+  try {
+    if (localStorage.getItem("user-region")) return;
+
+    const res = await fetch("/api/geo");
+    if (!res.ok) return;
+
+    const data = (await res.json()) as { country: string | null };
+    if (data.country && /^[A-Z]{2}$/.test(data.country)) {
+      localStorage.setItem("cf-region", data.country);
+    }
+  } catch {
+    /* ignore — fall back to locale/timezone detection */
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,11 @@ import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App.tsx'
 import './index.css'
+import { bootstrapRegion } from './lib/region-bootstrap'
+
+// Resolve the user's real region from the Cloudflare edge as early as
+// possible so streaming-availability lookups use the correct country.
+bootstrapRegion();
 
 // Create a client
 const queryClient = new QueryClient({

--- a/src/utils/regionDetection.ts
+++ b/src/utils/regionDetection.ts
@@ -28,13 +28,14 @@ export const supportedRegions = [
 
 /**
  * Synchronous region detection. Priority:
- * 1. Stored user preference (explicit choice always wins)
- * 2. Locale country part (e.g. "pl-PL" -> PL)
- * 3. Timezone heuristic
- * 4. Browser language
+ * 1. Stored user preference (explicit manual choice always wins)
+ * 2. Cloudflare edge country (the user's real location, cached at startup)
+ * 3. Locale country part (e.g. "pl-PL" -> PL)
+ * 4. Timezone heuristic
+ * 5. Browser language
  */
 export function detectUserRegion(): string {
-  // 1. Stored preference
+  // 1. Stored manual preference
   try {
     const stored = localStorage.getItem('user-region');
     if (stored && supportedRegions.includes(stored.toUpperCase())) {
@@ -44,7 +45,19 @@ export function detectUserRegion(): string {
     console.warn('Could not access localStorage:', error);
   }
 
-  // 2. Locale country part
+  // 2. Cloudflare edge country (cached by the startup geo bootstrap).
+  // Accept any ISO-3166 alpha-2 — TMDB watch providers covers far more
+  // countries than the app's UI region list.
+  try {
+    const cf = localStorage.getItem('cf-region');
+    if (cf && /^[A-Z]{2}$/.test(cf.toUpperCase())) {
+      return cf.toUpperCase();
+    }
+  } catch {
+    /* ignore */
+  }
+
+  // 3. Locale country part
   const locale = navigator.language || 'en-US';
   const localeParts = locale.split('-');
   if (localeParts.length >= 2) {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -13,6 +13,15 @@ const app = new Hono<{ Bindings: Env }>();
 
 app.get("/api/health", (c) => c.json({ ok: true, timestamp: new Date().toISOString() }));
 
+// Authoritative region from the Cloudflare edge (the user's real country).
+// Far more accurate than guessing from browser locale/timezone; the SPA
+// caches this for streaming-availability lookups. "XX"/"T1" = unknown/Tor.
+app.get("/api/geo", (c) => {
+  const country = (c.req.raw as unknown as { cf?: { country?: string } }).cf?.country;
+  const valid = country && country !== "XX" && country !== "T1";
+  return c.json({ country: valid ? country.toUpperCase() : null });
+});
+
 // Better Auth: sign-up/sign-in/sign-out/session under /api/auth/*
 app.on(["GET", "POST"], "/api/auth/*", (c) => createAuth(c.env).handler(c.req.raw));
 

--- a/worker/routes/streaming.ts
+++ b/worker/routes/streaming.ts
@@ -17,7 +17,10 @@ streamingRoutes.post("/streaming-availability", async (c) => {
   const body = await c.req.json<{ tmdbIds?: number[]; country?: string; forceRefresh?: boolean }>().catch(() => null);
 
   const tmdbIds = body?.tmdbIds;
-  const country = (body?.country || "pl").toUpperCase();
+  // Client country wins (it carries the user's manual choice / edge-cached
+  // region); fall back to the Cloudflare edge country, then PL.
+  const cfCountry = (c.req.raw as unknown as { cf?: { country?: string } }).cf?.country;
+  const country = (body?.country || cfCountry || "pl").toUpperCase();
   const forceRefresh = body?.forceRefresh === true;
 
   if (!tmdbIds || !Array.isArray(tmdbIds) || tmdbIds.length === 0) {


### PR DESCRIPTION
## Cel

Doprowadzić dostępność filmów/seriali do w 100% poprawnych danych. Główną przyczyną błędów był **region**: do tej pory zgadywany z `locale`/strefy czasowej, więc np. Polak z przeglądarką `en-US` widział katalog USA. Skoro aplikacja działa teraz na Cloudflare, używamy **prawdziwego kraju użytkownika z edge'a** (`request.cf.country`) — najdokładniejszego dostępnego źródła.

## Zmiany

- **Worker:** nowy `GET /api/geo` zwraca `request.cf.country`; trasa streamingu używa kraju z edge'a jako fallbacku, gdy klient nie poda własnego.
- **Klient:** bootstrap przy starcie cache'uje kraj z edge'a (`cf-region`), a `detectUserRegion()` preferuje go ponad zgadywanie z locale/strefy. Ręczny wybór regionu (`user-region`) nadal ma pierwszeństwo. Akceptujemy dowolny kod ISO-3166 alpha-2 (TMDB watch providers pokrywa znacznie więcej krajów niż lista UI).

## Dlaczego to daje poprawne dane

- Źródło danych to TMDB watch providers (zasilane JustWatch) — to samo, co widać na JustWatch, aktualny stan dla danego kraju; RapidAPI jako uzupełnienie.
- Zmyślone fallbacki usunięte (PR #2), abonament oddzielony od wypożyczenia/kupna.
- Region jest częścią każdego klucza cache (D1 i localStorage), więc poprawiona detekcja nigdy nie poda danych z innego regionu.

## Weryfikacja

- `tsc` (app + worker) i `vite build` przechodzą.
- Lokalnie: `GET /api/geo` zwraca kraj, trasa streamingu zachowuje poprawny kontrakt i fallback kraju.

> Stack: #3 → #4 → #5 → **ten PR**. Żeby zadziałało na produkcji, wdrożenie Cloudflare musi obejmować te commity (merge PR-ów w dół albo wskazanie brancha w panelu), a na Workerze musi być ustawiony `TMDB_API_KEY`.

https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG)_