### PR TITLE
Durable title search: server-proxied multi search (movies + TV) with media_type

### DIFF
--- a/src/components/navigation/SearchCommandDialog.tsx
+++ b/src/components/navigation/SearchCommandDialog.tsx
@@ -10,7 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useQuery } from '@tanstack/react-query';
-import { searchMovies } from '@/services/tmdb/search';
+import { searchTitles } from '@/services/tmdb/search';
 import { useLocalStorage } from '@/hooks/use-local-storage';
 import { cn } from '@/lib/utils';
 
@@ -43,7 +43,7 @@ export const SearchCommandDialog = ({
   // Search results query
   const { data: searchResults = [], isLoading } = useQuery({
     queryKey: ['search', query],
-    queryFn: () => searchMovies(query),
+    queryFn: () => searchTitles(query),
     enabled: query.length >= 2,
     staleTime: 5 * 60 * 1000,
   });

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -3,7 +3,7 @@ import { useState, useMemo } from "react";
 import { Navigation } from "@/components/Navigation";
 import { Search as SearchIcon, Star, ChevronRight, Film, User, Clapperboard } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { searchMovies, searchPeople, type TMDBMovie, type TMDBPerson } from "@/services/tmdb";
+import { searchTitles, searchPeople, type TMDBMovie, type TMDBPerson } from "@/services/tmdb";
 import { motion, AnimatePresence } from "framer-motion";
 import { MouseGlow } from "@/components/effects/MouseGlow";
 import { Footer } from "@/components/Footer";
@@ -20,8 +20,8 @@ const Search = () => {
   const { selectedMovie, isModalOpen, openModal, closeModal } = useMovieModal();
 
   const { data: movies = [], isLoading: isLoadingMovies } = useQuery({
-    queryKey: ["searchMovies", query],
-    queryFn: () => searchMovies(query),
+    queryKey: ["searchTitles", query],
+    queryFn: () => searchTitles(query),
     enabled: query.length > 1 && searchType === "Movies",
   });
 

--- a/src/services/tmdb/search.ts
+++ b/src/services/tmdb/search.ts
@@ -1,8 +1,49 @@
 
-import { supabase } from "@/integrations/supabase/client";
+import { api } from "@/lib/api-client";
 import { TMDB_BASE_URL, getTMDBApiKey } from "./config";
 import type { TMDBMovie, TMDBPerson } from "./types";
 import i18n from "@/i18n";
+
+interface WorkerSearchItem {
+  id: number;
+  mediaType: "movie" | "tv" | "person";
+  title: string;
+  posterPath: string | null;
+  releaseDate: string | null;
+  voteAverage: number;
+  overview: string;
+}
+
+/**
+ * Title search via the Cloudflare Worker (TMDB multi search).
+ * Returns movies AND TV shows, each tagged with media_type so the
+ * streaming-availability lookup can query the exact TMDB endpoint.
+ * The TMDB key stays server-side.
+ */
+export async function searchTitles(query: string): Promise<TMDBMovie[]> {
+  if (!query || query.length < 2) return [];
+
+  const lang = i18n.language || "en-US";
+  const { results } = await api.get<{ results: WorkerSearchItem[] }>(
+    `/search?q=${encodeURIComponent(query)}&lang=${encodeURIComponent(lang)}`
+  );
+
+  return results
+    .filter((r) => r.mediaType === "movie" || r.mediaType === "tv")
+    .map((r) => ({
+      id: r.id,
+      title: r.title,
+      release_date: r.releaseDate || "",
+      overview: r.overview || "",
+      poster_path: r.posterPath || "",
+      backdrop_path: null,
+      vote_average: r.voteAverage || 0,
+      vote_count: 0,
+      popularity: 0,
+      genre_ids: [],
+      media_type: r.mediaType as "movie" | "tv",
+    }));
+}
 
 export async function searchMovies(query: string): Promise<TMDBMovie[]> {
   try {

--- a/src/services/tmdb/types.ts
+++ b/src/services/tmdb/types.ts
@@ -13,6 +13,8 @@ export interface TMDBMovie {
   video_id?: string;
   genres?: Array<{ id: number; name: string; }>;
   explanations?: string[];
+  /** 'movie' | 'tv' when known (e.g. from multi search) — drives exact streaming lookup */
+  media_type?: 'movie' | 'tv';
 }
 
 export interface TMDBPerson {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { createAuth } from "./auth";
 import { streamingRoutes } from "./routes/streaming";
+import { searchRoutes } from "./routes/search";
 import { dataRoutes } from "./routes/data";
 import type { Env } from "./env";
 
@@ -30,6 +31,7 @@ app.get("/api/keys/tmdb", (c) => c.json({ key: c.env.TMDB_API_KEY }));
 app.get("/api/keys/youtube", (c) => c.json({ key: c.env.YOUTUBE_API_KEY || "" }));
 
 app.route("/api", streamingRoutes);
+app.route("/api", searchRoutes);
 app.route("/api", dataRoutes);
 
 // Non-API requests that still reach the Worker fall back to the SPA assets

--- a/worker/lib/streaming.ts
+++ b/worker/lib/streaming.ts
@@ -28,6 +28,8 @@ export interface MovieStreamingData {
   source?: string;
 }
 
+export type MediaType = "movie" | "tv";
+
 const TYPE_PRIORITY: Record<string, number> = { subscription: 4, free: 3, rent: 2, buy: 1 };
 
 // TMDB/JustWatch report plan variants ("Netflix Standard with Ads")
@@ -85,15 +87,18 @@ export const buildResult = (tmdbId: number, title: string, options: StreamingOpt
 // =====================================================
 // SOURCE 1: TMDB Watch Providers (FREE, JustWatch-backed, current data)
 // =====================================================
-const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiKey: string): Promise<MovieStreamingData | null> => {
+const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiKey: string, mediaType?: MediaType): Promise<MovieStreamingData | null> => {
   if (!tmdbApiKey) return null;
 
   const region = country.toUpperCase();
 
-  const endpoints = [
-    { url: `https://api.themoviedb.org/3/movie/${tmdbId}?api_key=${tmdbApiKey}&append_to_response=watch/providers`, type: 'movie' },
-    { url: `https://api.themoviedb.org/3/tv/${tmdbId}?api_key=${tmdbApiKey}&append_to_response=watch/providers`, type: 'tv' }
+  // Query the exact endpoint when the media type is known (from search);
+  // otherwise try movie first, then TV.
+  const allEndpoints = [
+    { url: `https://api.themoviedb.org/3/movie/${tmdbId}?api_key=${tmdbApiKey}&append_to_response=watch/providers`, type: 'movie' as MediaType },
+    { url: `https://api.themoviedb.org/3/tv/${tmdbId}?api_key=${tmdbApiKey}&append_to_response=watch/providers`, type: 'tv' as MediaType }
   ];
+  const endpoints = mediaType ? allEndpoints.filter(e => e.type === mediaType) : allEndpoints;
 
   for (const endpoint of endpoints) {
     try {
@@ -157,13 +162,14 @@ const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiK
 // =====================================================
 // SOURCE 2: RapidAPI Streaming Availability (enrichment)
 // =====================================================
-const fetchRapidApiStreaming = async (tmdbId: number, country: string, rapidApiKey: string): Promise<MovieStreamingData | null> => {
+const fetchRapidApiStreaming = async (tmdbId: number, country: string, rapidApiKey: string, mediaType?: MediaType): Promise<MovieStreamingData | null> => {
   if (!rapidApiKey) return null;
 
-  const endpoints = [
-    `https://streaming-availability.p.rapidapi.com/shows/movie/${tmdbId}?country=${country.toLowerCase()}`,
-    `https://streaming-availability.p.rapidapi.com/shows/series/${tmdbId}?country=${country.toLowerCase()}`
+  const allEndpoints = [
+    { url: `https://streaming-availability.p.rapidapi.com/shows/movie/${tmdbId}?country=${country.toLowerCase()}`, type: "movie" as MediaType },
+    { url: `https://streaming-availability.p.rapidapi.com/shows/series/${tmdbId}?country=${country.toLowerCase()}`, type: "tv" as MediaType }
   ];
+  const endpoints = (mediaType ? allEndpoints.filter(e => e.type === mediaType) : allEndpoints).map(e => e.url);
 
   for (const endpoint of endpoints) {
     try {
@@ -250,15 +256,16 @@ const extractStreamingOptions = (countryData: unknown): any[] => {
 export const fetchStreamingData = async (
   tmdbId: number,
   country: string,
-  keys: { tmdbApiKey: string; rapidApiKey?: string }
+  keys: { tmdbApiKey: string; rapidApiKey?: string },
+  mediaType?: MediaType
 ): Promise<MovieStreamingData> => {
-  const tmdbResult = await fetchTmdbWatchProviders(tmdbId, country, keys.tmdbApiKey);
+  const tmdbResult = await fetchTmdbWatchProviders(tmdbId, country, keys.tmdbApiKey, mediaType);
   if (tmdbResult && tmdbResult.streamingOptions.length > 0) {
     return tmdbResult;
   }
 
   if (keys.rapidApiKey) {
-    const rapidResult = await fetchRapidApiStreaming(tmdbId, country, keys.rapidApiKey);
+    const rapidResult = await fetchRapidApiStreaming(tmdbId, country, keys.rapidApiKey, mediaType);
     if (rapidResult && rapidResult.streamingOptions.length > 0) {
       return rapidResult;
     }

--- a/worker/routes/search.ts
+++ b/worker/routes/search.ts
@@ -1,0 +1,80 @@
+import { Hono } from "hono";
+import type { Env } from "../env";
+
+// Server-side TMDB title search (multi: movies + TV + people).
+// Keeps the TMDB key on the Worker, carries media_type to the client,
+// and caches results at the edge for speed and rate-limit safety.
+
+export const searchRoutes = new Hono<{ Bindings: Env }>();
+
+export interface SearchResultItem {
+  id: number;
+  mediaType: "movie" | "tv" | "person";
+  title: string;
+  posterPath: string | null;
+  profilePath: string | null;
+  releaseDate: string | null;
+  voteAverage: number;
+  overview: string;
+  knownForDepartment?: string;
+}
+
+interface TmdbMultiResult {
+  id: number;
+  media_type?: string;
+  title?: string;
+  name?: string;
+  poster_path?: string | null;
+  profile_path?: string | null;
+  release_date?: string;
+  first_air_date?: string;
+  vote_average?: number;
+  overview?: string;
+  known_for_department?: string;
+}
+
+searchRoutes.get("/search", async (c) => {
+  const q = c.req.query("q")?.trim();
+  const lang = c.req.query("lang") || "en-US";
+  const page = c.req.query("page") || "1";
+
+  if (!q || q.length < 2) return c.json({ results: [] });
+  if (!c.env.TMDB_API_KEY) return c.json({ error: "TMDB not configured" }, 500);
+
+  // Edge cache keyed by the public params only (never the API key)
+  const cache = caches.default;
+  const cacheKey = new Request(
+    new URL(`/api/search?q=${encodeURIComponent(q)}&lang=${lang}&page=${page}`, c.req.url).toString()
+  );
+  const hit = await cache.match(cacheKey);
+  if (hit) return hit;
+
+  const tmdbUrl =
+    `https://api.themoviedb.org/3/search/multi?api_key=${c.env.TMDB_API_KEY}` +
+    `&query=${encodeURIComponent(q)}&language=${encodeURIComponent(lang)}&include_adult=false&page=${page}`;
+
+  const res = await fetch(tmdbUrl);
+  if (!res.ok) return c.json({ error: "search failed" }, 502);
+
+  const data = (await res.json()) as { results?: TmdbMultiResult[] };
+
+  const results: SearchResultItem[] = (data.results || [])
+    .filter((r) => r.media_type === "movie" || r.media_type === "tv" || r.media_type === "person")
+    .map((r) => ({
+      id: r.id,
+      mediaType: r.media_type as SearchResultItem["mediaType"],
+      title: r.title || r.name || "",
+      posterPath: r.poster_path ?? null,
+      profilePath: r.profile_path ?? null,
+      releaseDate: r.release_date || r.first_air_date || null,
+      voteAverage: r.vote_average ?? 0,
+      overview: r.overview || "",
+      knownForDepartment: r.known_for_department,
+    }))
+    .filter((r) => r.title);
+
+  const response = c.json({ results });
+  response.headers.set("Cache-Control", "public, max-age=600");
+  c.executionCtx.waitUntil(cache.put(cacheKey, response.clone()));
+  return response;
+});

--- a/worker/routes/streaming.ts
+++ b/worker/routes/streaming.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/d1";
 import { and, eq, gte, inArray, sql } from "drizzle-orm";
 import { streamingCache } from "../db/schema";
-import { fetchStreamingData, buildResult, type MovieStreamingData } from "../lib/streaming";
+import { fetchStreamingData, buildResult, type MovieStreamingData, type MediaType } from "../lib/streaming";
 import type { Env } from "../env";
 
 const CACHE_TTL_HOURS_DATA = 24;
@@ -11,12 +11,25 @@ const MAX_BATCH = 50;
 
 export const streamingRoutes = new Hono<{ Bindings: Env }>();
 
-// POST /api/streaming-availability { tmdbIds: number[], country?: string, forceRefresh?: boolean }
+// POST /api/streaming-availability
+//   { tmdbIds: number[], country?, forceRefresh? }                  (movie heuristic)
+//   { items: {tmdbId, mediaType}[], country?, forceRefresh? }       (exact per title)
 // Same response contract as the streaming-availability-pro Supabase function.
 streamingRoutes.post("/streaming-availability", async (c) => {
-  const body = await c.req.json<{ tmdbIds?: number[]; country?: string; forceRefresh?: boolean }>().catch(() => null);
+  const body = await c.req.json<{
+    tmdbIds?: number[];
+    items?: { tmdbId: number; mediaType?: MediaType }[];
+    country?: string;
+    forceRefresh?: boolean;
+  }>().catch(() => null);
 
-  const tmdbIds = body?.tmdbIds;
+  // Accept either a plain id list or {tmdbId, mediaType} items.
+  const tmdbIds = body?.items
+    ? body.items.map(i => i.tmdbId)
+    : body?.tmdbIds;
+  const mediaTypeById = new Map<number, MediaType | undefined>(
+    (body?.items || []).map(i => [i.tmdbId, i.mediaType])
+  );
   // Client country wins (it carries the user's manual choice / edge-cached
   // region); fall back to the Cloudflare edge country, then PL.
   const cfCountry = (c.req.raw as unknown as { cf?: { country?: string } }).cf?.country;
@@ -62,7 +75,7 @@ streamingRoutes.post("/streaming-availability", async (c) => {
 
   if (missingIds.length > 0) {
     const keys = { tmdbApiKey: c.env.TMDB_API_KEY, rapidApiKey: c.env.RAPIDAPI_KEY };
-    const settled = await Promise.allSettled(missingIds.map(id => fetchStreamingData(id, country, keys)));
+    const settled = await Promise.allSettled(missingIds.map(id => fetchStreamingData(id, country, keys, mediaTypeById.get(id))));
 
     settled.forEach((result, index) => {
       if (result.status === "fulfilled") {


### PR DESCRIPTION
## Decyzja (cięższa, ale docelowa — żeby nie poprawiać w przyszłości)

Dotychczasowe wyszukiwanie tytułów było słabe i kruche: tylko filmy (`/search/movie`, brak seriali — mimo że placeholder obiecuje „movies, TV shows, actors"), klucz TMDB wysyłany do przeglądarki, i brak `media_type` (przez co dostępność musiała zgadywać film vs serial). Zamiast łatać, przebudowuję to porządnie.

## Co robię

- **Worker `GET /api/search`** proxuje TMDB `/search/multi` — wyszukiwanie zwraca **filmy i seriale** (oraz osoby), klucz TMDB zostaje po stronie serwera, a wyniki są cache'owane na edge'u (10 min).
- Każdy wynik niesie **`media_type`**. Endpoint dostępności przyjmuje teraz `items: {tmdbId, mediaType}[]`, a Worker odpytuje **dokładny** endpoint TMDB (movie vs tv), gdy typ jest znany — znika niejednoznaczność film/serial. Stara forma `tmdbIds[]` nadal działa (heurystyka movie→tv).
- **Frontend:** nowa funkcja `searchTitles()` używana przez stronę wyszukiwania i paletę poleceń (Ctrl-K); `TMDBMovie` zyskuje opcjonalne `media_type`.

## Dlaczego to „na przyszłość"

- Ustanawia wzorzec **proxy TMDB przez Worker** (klucz na serwerze, cache, kontrola limitów), który można rozszerzyć na pozostałe wywołania TMDB.
- `media_type` przepływa od wyszukiwania do dostępności, więc seriale są obsłużone tak samo poprawnie jak filmy — bez przyszłych łatek.

## Weryfikacja

- `tsc` (app + worker) i `vite build` przechodzą.
- `wrangler dev`: `/api/search` zwraca pusto dla krótkich zapytań, gracefully zwraca błąd bez klucza (z kluczem w produkcji zwraca wyniki), a ścieżka `items[]` w dostępności obsługuje równ. film i serial.

## Pozostała (opcjonalna) drobnostka

Przekazanie `media_type` z karty/modala do hooka dostępności w UI — addytywne, bez przebudowy (heurystyka movie→tv i tak daje poprawny wynik dla seriali). Klucz TMDB nadal trafia do przeglądarki w wyszukiwaniu osób i innych wywołaniach TMDB — do migracji tym samym wzorcem później.

> Stack: #3 → #4 → #5 → #6 → **ten PR**.

https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG)_