### PR TITLE
Harden streaming availability: never cache transient failures + tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1",
+        "vitest": "2.1.9",
         "wrangler": "4.100.0"
       }
     },
@@ -3804,7 +3805,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -4101,6 +4102,133 @@
         "vite": "^4 || ^5"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
@@ -4220,6 +4348,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -4627,6 +4765,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4680,6 +4828,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4695,6 +4860,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -5387,7 +5562,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5406,6 +5581,16 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -5681,6 +5866,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5712,7 +5904,7 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5942,7 +6134,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -5963,6 +6155,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6825,6 +7027,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/lovable-tagger": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/lovable-tagger/-/lovable-tagger-1.1.8.tgz",
@@ -7293,7 +7502,7 @@
       "version": "0.30.12",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
       "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -7443,7 +7652,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -7723,6 +7932,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8348,7 +8567,7 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
       "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -8509,6 +8728,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8539,6 +8765,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/streaming-availability": {
       "version": "4.4.0",
@@ -8833,6 +9073,50 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9077,7 +9361,7 @@
       "version": "5.4.10",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
       "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -9133,6 +9417,109 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -9165,6 +9552,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "worker:dev": "wrangler dev",
     "worker:deploy": "npm run build && wrangler deploy",
     "worker:typecheck": "tsc -p tsconfig.worker.json",
-    "worker:migrate": "wrangler d1 migrations apply moviefinder --remote"
+    "worker:migrate": "wrangler d1 migrations apply moviefinder --remote",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -96,6 +97,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
+    "vitest": "2.1.9",
     "wrangler": "4.100.0"
   },
   "overrides": {

--- a/src/services/streamingAvailabilityPro.ts
+++ b/src/services/streamingAvailabilityPro.ts
@@ -26,6 +26,8 @@ export interface MovieStreamingData {
   rentBuyServices?: string[];
   hasStreaming: boolean;
   lastUpdated: string;
+  /** Origin: tmdb | rapidapi | cache | none | error */
+  source?: string;
 }
 
 export interface StreamingBatchResponse {
@@ -139,7 +141,11 @@ export const getStreamingAvailabilityBatch = async (
     );
 
     normalizedResponseData.forEach(movieData => {
-      setCachedData(movieData.tmdbId, targetCountry, movieData);
+      // Never cache transient failures — only real answers (incl. genuine
+      // "not available"). Synthetic placeholders have no source → skip.
+      if (movieData.source && movieData.source !== 'error') {
+        setCachedData(movieData.tmdbId, targetCountry, movieData);
+      }
     });
 
     // Combine cached and new results

--- a/worker/lib/streaming.test.ts
+++ b/worker/lib/streaming.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fetchStreamingData, buildResult, type StreamingOption } from "./streaming";
+
+const KEYS = { tmdbApiKey: "test-key" };
+
+/** Minimal Response-like stub for the worker's fetch usage. */
+function res(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function mockFetch(handler: (url: string) => Response | Promise<Response>) {
+  globalThis.fetch = vi.fn((input: any) => Promise.resolve(handler(String(input)))) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildResult", () => {
+  it("separates subscription/free from rent/buy and sorts best-first", () => {
+    const options: StreamingOption[] = [
+      { service: "Apple TV", serviceLogo: "", link: "", type: "rent", quality: "HD" },
+      { service: "Netflix", serviceLogo: "", link: "", type: "subscription", quality: "HD" },
+      { service: "YouTube", serviceLogo: "", link: "", type: "buy", quality: "HD" },
+    ];
+    const r = buildResult(1, "X", options, "tmdb");
+    expect(r.availableServices).toEqual(["Netflix"]);
+    expect(r.rentBuyServices).toEqual(["Apple TV", "YouTube"]);
+    expect(r.hasStreaming).toBe(true);
+    expect(r.streamingOptions[0].type).toBe("subscription"); // sorted best-first
+  });
+
+  it("reports hasStreaming=false when only rent/buy exist", () => {
+    const r = buildResult(1, "X", [
+      { service: "Apple TV", serviceLogo: "", link: "", type: "buy", quality: "HD" },
+    ], "tmdb");
+    expect(r.hasStreaming).toBe(false);
+    expect(r.availableServices).toEqual([]);
+    expect(r.rentBuyServices).toEqual(["Apple TV"]);
+  });
+});
+
+describe("fetchStreamingData — TMDB watch providers", () => {
+  it("parses providers, dedupes plan variants, splits subscription vs rent/buy", async () => {
+    mockFetch((url) =>
+      url.includes("/movie/603")
+        ? res(200, {
+            title: "The Matrix",
+            "watch/providers": {
+              results: {
+                PL: {
+                  flatrate: [
+                    { provider_name: "Netflix", logo_path: "/n.jpg" },
+                    { provider_name: "Netflix Standard with Ads", logo_path: "/n2.jpg" },
+                  ],
+                  rent: [{ provider_name: "Apple TV", logo_path: "/a.jpg" }],
+                  buy: [{ provider_name: "Apple TV", logo_path: "/a.jpg" }],
+                },
+              },
+            },
+          })
+        : res(404, {})
+    );
+
+    const r = await fetchStreamingData(603, "PL", KEYS);
+    expect(r.source).toBe("tmdb");
+    expect(r.hasStreaming).toBe(true);
+    expect(r.availableServices).toEqual(["Netflix"]); // plan variant collapsed
+    expect(r.rentBuyServices).toEqual(["Apple TV"]); // rent+buy collapsed to one
+    expect(r.streamingOptions.filter((o) => o.service === "Netflix")).toHaveLength(1);
+  });
+
+  it("returns a genuine empty (cacheable) when TMDB responds with no region providers", async () => {
+    mockFetch((url) =>
+      url.includes("/movie/603")
+        ? res(200, { title: "X", "watch/providers": { results: { US: { flatrate: [] } } } })
+        : res(404, {})
+    );
+
+    const r = await fetchStreamingData(603, "PL", KEYS);
+    expect(r.source).toBe("none");
+    expect(r.hasStreaming).toBe(false);
+    expect(r.streamingOptions).toEqual([]);
+  });
+
+  it("THROWS (must not cache as empty) when TMDB is unreachable", async () => {
+    mockFetch(() => {
+      throw new Error("network down");
+    });
+    await expect(fetchStreamingData(603, "PL", KEYS)).rejects.toThrow();
+  });
+
+  it("THROWS on TMDB 5xx (transient), so it is retried rather than cached empty", async () => {
+    mockFetch(() => res(503, {}));
+    await expect(fetchStreamingData(603, "PL", KEYS)).rejects.toThrow();
+  });
+
+  it("queries only the TV endpoint when mediaType=tv", async () => {
+    const seen: string[] = [];
+    mockFetch((url) => {
+      seen.push(url);
+      return url.includes("/tv/1399")
+        ? res(200, { name: "GoT", "watch/providers": { results: { PL: { flatrate: [{ provider_name: "HBO Max" }] } } } })
+        : res(404, {});
+    });
+
+    const r = await fetchStreamingData(1399, "PL", KEYS, "tv");
+    expect(r.hasStreaming).toBe(true);
+    expect(r.availableServices).toEqual(["HBO Max"]);
+    expect(seen.every((u) => u.includes("/tv/"))).toBe(true); // never hit /movie/
+  });
+});

--- a/worker/lib/streaming.ts
+++ b/worker/lib/streaming.ts
@@ -100,14 +100,33 @@ const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiK
   ];
   const endpoints = mediaType ? allEndpoints.filter(e => e.type === mediaType) : allEndpoints;
 
+  // Track whether TMDB actually answered. If no endpoint responds (network
+  // error / 5xx / auth failure) we must NOT report "no providers" — that
+  // would be cached as unavailable. Throwing lets the caller treat it as a
+  // transient error (not cached, retried next time).
+  let respondedOk = false;
+
   for (const endpoint of endpoints) {
+    let response: Response;
     try {
-      const response = await fetch(endpoint.url, {
+      response = await fetch(endpoint.url, {
         headers: { 'Content-Type': 'application/json' }
       });
+    } catch (error) {
+      console.error(`TMDB network error for ${tmdbId} (${endpoint.type}):`, error);
+      continue; // transport failure — leave respondedOk false
+    }
 
-      if (!response.ok) continue;
+    // 404 = this id isn't that media type: a real answer, just not found.
+    if (response.status === 404) { respondedOk = true; continue; }
+    // 401/403/429/5xx = transient/config failure — do not treat as "empty".
+    if (!response.ok) {
+      console.error(`TMDB HTTP ${response.status} for ${tmdbId} (${endpoint.type})`);
+      continue;
+    }
+    respondedOk = true;
 
+    try {
       const data: any = await response.json();
       const watchProviders = data['watch/providers']?.results?.[region];
 
@@ -152,11 +171,14 @@ const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiK
         return buildResult(tmdbId, movieTitle, streamingOptions, 'tmdb');
       }
     } catch (error) {
-      console.error(`TMDB error for ${tmdbId} (${endpoint.type}):`, error);
+      console.error(`TMDB parse error for ${tmdbId} (${endpoint.type}):`, error);
     }
   }
 
-  return null;
+  // Responded but no providers for this region = genuine "not available".
+  if (respondedOk) return null;
+  // Nothing answered = transient failure; signal so it isn't cached as empty.
+  throw new Error(`TMDB unreachable for ${tmdbId}`);
 };
 
 // =====================================================
@@ -259,11 +281,21 @@ export const fetchStreamingData = async (
   keys: { tmdbApiKey: string; rapidApiKey?: string },
   mediaType?: MediaType
 ): Promise<MovieStreamingData> => {
-  const tmdbResult = await fetchTmdbWatchProviders(tmdbId, country, keys.tmdbApiKey, mediaType);
-  if (tmdbResult && tmdbResult.streamingOptions.length > 0) {
-    return tmdbResult;
+  // Primary, authoritative source: TMDB watch providers (JustWatch data).
+  // Throws if TMDB was unreachable; returns null if it responded with no
+  // providers for the region (a genuine "not available").
+  let tmdbResponded = false;
+  try {
+    const tmdbResult = await fetchTmdbWatchProviders(tmdbId, country, keys.tmdbApiKey, mediaType);
+    tmdbResponded = true;
+    if (tmdbResult && tmdbResult.streamingOptions.length > 0) {
+      return tmdbResult;
+    }
+  } catch (error) {
+    console.error(`TMDB failed for ${tmdbId}:`, error);
   }
 
+  // Secondary: RapidAPI can recover (TMDB unreachable) or add coverage.
   if (keys.rapidApiKey) {
     const rapidResult = await fetchRapidApiStreaming(tmdbId, country, keys.rapidApiKey, mediaType);
     if (rapidResult && rapidResult.streamingOptions.length > 0) {
@@ -271,7 +303,13 @@ export const fetchStreamingData = async (
     }
   }
 
-  return buildResult(tmdbId, '', [], 'none');
+  // Only report (and let the route cache) "not available" when the
+  // authoritative source actually answered. Otherwise signal a transient
+  // failure so it is NOT cached as empty and is retried next time.
+  if (tmdbResponded) {
+    return buildResult(tmdbId, '', [], 'none');
+  }
+  throw new Error(`streaming lookup failed for ${tmdbId} (no source responded)`);
 };
 
 // =====================================================


### PR DESCRIPTION
## Cel
Usunąć wszelkie wątpliwości/błędy w dostępności tytułów w serwisach. Po audycie całej ścieżki znalazłem jedno realne ryzyko poprawności i je zamknąłem, plus dołożyłem testy automatyczne.

## Problem
Przejściowa awaria TMDB (sieć / 5xx / błąd klucza) była „połykana" i zwracana jako **pusty wynik**, który następnie był **cache'owany jako „niedostępne"** (D1 24/6h, localStorage 3h). Efekt: tytuł realnie dostępny mógł godzinami pokazywać się jako niedostępny.

## Naprawa
**Worker (`worker/lib/streaming.ts`)**
- `fetchTmdbWatchProviders` rozróżnia teraz „odpowiedział, brak providerów w regionie" (prawdziwa pustka) od „nie odpowiedział" (sieć/5xx/401/403/429). W drugim przypadku **rzuca wyjątek** zamiast zwracać pustkę.
- `fetchStreamingData` zwraca pusty wynik **tylko gdy źródło autorytatywne (TMDB) faktycznie odpowiedziało**; w przeciwnym razie rzuca. Trasa już wyklucza pozycje „error" z zapisu do D1 → przejściowe awarie są ponawiane, nie zatruwają cache.

**Frontend (`services/streamingAvailabilityPro.ts`)**
- `MovieStreamingData` niesie `source`; cache w localStorage **pomija pozycje `source: "error"`** (zapisywane są tylko realne odpowiedzi, w tym uczciwe „niedostępne").

## Testy (vitest, nowość)
`worker/lib/streaming.test.ts` pokrywa dokładnie przypadki, które historycznie powodowały błędy:
- rozdzielenie abonament/free vs wypożyczenie/kupno,
- deduplikacja wariantów planów („Netflix Standard with Ads" → Netflix),
- prawdziwa pustka (cache'owalna),
- przejściowa awaria → wyjątek (sieć i 5xx) → **nie cache'owane**,
- routing po `media_type` (serial pyta tylko endpoint TV).

`npm test` → **7/7 zielonych**. `tsc` (app + worker) i `vite build` przechodzą.

## Uwaga o weryfikacji
To środowisko nie ma wyjścia do sieci (TMDB i live zwracają 403), więc nie dało się odpytać żywego API stąd — poprawność jest zweryfikowana przez testy end-to-end transformacji z zamockowanymi odpowiedziami TMDB. Po wdrożeniu wystarczy `npm test` w CI jako stały strażnik regresji.

https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG)_