### PR TITLE
Address audit: hide TMDB key, real streaming links, TV recommendations, 404, favorites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1",
+        "vitest": "2.1.9",
         "wrangler": "4.100.0"
       }
     },
@@ -3804,7 +3805,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -4101,6 +4102,133 @@
         "vite": "^4 || ^5"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
@@ -4220,6 +4348,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -4627,6 +4765,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4680,6 +4828,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4695,6 +4860,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -5387,7 +5562,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5406,6 +5581,16 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -5681,6 +5866,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5712,7 +5904,7 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5942,7 +6134,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -5963,6 +6155,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6825,6 +7027,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/lovable-tagger": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/lovable-tagger/-/lovable-tagger-1.1.8.tgz",
@@ -7293,7 +7502,7 @@
       "version": "0.30.12",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
       "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -7443,7 +7652,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -7723,6 +7932,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8348,7 +8567,7 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
       "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -8509,6 +8728,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8539,6 +8765,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/streaming-availability": {
       "version": "4.4.0",
@@ -8833,6 +9073,50 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9077,7 +9361,7 @@
       "version": "5.4.10",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
       "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -9133,6 +9417,109 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -9165,6 +9552,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "worker:dev": "wrangler dev",
     "worker:deploy": "npm run build && wrangler deploy",
     "worker:typecheck": "tsc -p tsconfig.worker.json",
-    "worker:migrate": "wrangler d1 migrations apply moviefinder --remote"
+    "worker:migrate": "wrangler d1 migrations apply moviefinder --remote",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -96,6 +97,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
+    "vitest": "2.1.9",
     "wrangler": "4.100.0"
   },
   "overrides": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import QuickStart from "./pages/QuickStart";
 import Services from "./pages/Services";
 import Auth from "./pages/Auth";
 import Dashboard from "./pages/Dashboard";
+import NotFound from "./pages/NotFound";
 import "./App.css";
 
 const queryClient = new QueryClient();
@@ -52,6 +53,7 @@ function App() {
               <Route path="/auth" element={<Auth />} />
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/quiz/group/:groupId" element={<GroupQuizPage />} />
+              <Route path="*" element={<NotFound />} />
             </Routes>
           </Suspense>
         </BrowserRouter>

--- a/src/components/movie/EnhancedMovieModal.tsx
+++ b/src/components/movie/EnhancedMovieModal.tsx
@@ -50,8 +50,11 @@ export const EnhancedMovieModal = ({
       try {
         const userLocale = navigator.language || "en-US";
         const movieLang = userLocale.split("-")[0];
+        // Via the Worker TMDB proxy (key stays server-side).
+        // include_image_language adds EN + language-agnostic images so the
+        // Media tab isn't empty for non-EN locales.
         const response = await fetch(
-          `https://api.themoviedb.org/3/movie/${movie.id}?api_key=${await import("@/services/tmdb/config").then((m) => m.getTMDBApiKey())}&append_to_response=credits,videos,images,similar,reviews&language=${movieLang}`
+          `/api/tmdb/movie/${movie.id}?append_to_response=credits,videos,images,similar,reviews&language=${movieLang}&include_image_language=${movieLang},en,null`
         );
         if (response.ok) {
           setMovieDetails(await response.json());

--- a/src/components/quiz/EnhancedQuiz.tsx
+++ b/src/components/quiz/EnhancedQuiz.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { api, ApiError } from "@/lib/api-client";
+import { saveMovies } from "@/services/user";
 import { useToast } from "@/hooks/use-toast";
 import { Movie } from "@/types/movie";
 import { ProjectorBeam } from "@/components/effects/ProjectorBeam";
@@ -337,10 +338,19 @@ const EnhancedQuiz: React.FC<EnhancedQuizProps> = ({ onBack, onComplete, userPre
     }
   };
 
-  const handleLikeMovie = (movie: Movie) => {
+  const handleLikeMovie = async (movie: Movie) => {
     setLikedMovie(movie);
     playMagic();
-    toast({ title: `❤️ ${movie.title} added!`, description: "Great choice! You can find it in your favorites." });
+    try {
+      await saveMovies([{ tmdb_id: movie.id, title: movie.title, poster_path: (movie as { poster_path?: string }).poster_path }]);
+      toast({ title: `❤️ ${movie.title} added!`, description: "Saved to your favorites." });
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 401) {
+        toast({ title: "Sign in to save favorites", description: "Create an account to keep your picks.", variant: "destructive" });
+      } else {
+        toast({ title: "Couldn't save to favorites", variant: "destructive" });
+      }
+    }
   };
 
   const handleRetakeQuiz = () => {

--- a/src/components/quiz/hooks/useComprehensiveQuizLogic.ts
+++ b/src/components/quiz/hooks/useComprehensiveQuizLogic.ts
@@ -206,7 +206,7 @@ export const useComprehensiveQuizLogic = () => {
       console.log('🎬 Quiz API call with params:', params.toString());
 
       const response = await fetch(
-        `https://api.themoviedb.org/3/discover/movie?${params}`
+        `/api/tmdb/discover/movie?${params}`
       );
 
       if (!response.ok) {

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+import { Film } from "lucide-react";
+
+const NotFound = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#02020a] px-4">
+      <div className="text-center max-w-md">
+        <div className="w-20 h-20 rounded-2xl bg-purple-600/20 border border-purple-500/30 flex items-center justify-center mx-auto mb-6">
+          <Film className="w-10 h-10 text-purple-400" />
+        </div>
+        <h1 className="text-6xl font-black text-white mb-2">404</h1>
+        <p className="text-white/50 mb-8">
+          This scene didn't make the final cut — the page you're looking for doesn't exist.
+        </p>
+        <Link
+          to="/"
+          className="inline-block px-8 h-12 leading-[3rem] rounded-2xl bg-purple-600 hover:bg-purple-500 text-white font-bold uppercase tracking-widest text-sm transition-all"
+        >
+          Back to home
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/src/services/streamingAvailabilityPro.ts
+++ b/src/services/streamingAvailabilityPro.ts
@@ -26,6 +26,8 @@ export interface MovieStreamingData {
   rentBuyServices?: string[];
   hasStreaming: boolean;
   lastUpdated: string;
+  /** Origin: tmdb | rapidapi | cache | none | error */
+  source?: string;
 }
 
 export interface StreamingBatchResponse {
@@ -139,7 +141,11 @@ export const getStreamingAvailabilityBatch = async (
     );
 
     normalizedResponseData.forEach(movieData => {
-      setCachedData(movieData.tmdbId, targetCountry, movieData);
+      // Never cache transient failures — only real answers (incl. genuine
+      // "not available"). Synthetic placeholders have no source → skip.
+      if (movieData.source && movieData.source !== 'error') {
+        setCachedData(movieData.tmdbId, targetCountry, movieData);
+      }
     });
 
     // Combine cached and new results

--- a/src/services/tmdb/config.ts
+++ b/src/services/tmdb/config.ts
@@ -1,17 +1,12 @@
-import { api } from "@/lib/api-client";
-
-export const TMDB_BASE_URL = "https://api.themoviedb.org/3";
+// All TMDB calls go through the Cloudflare Worker proxy (/api/tmdb/*),
+// which injects the API key server-side. The key is never sent to the
+// browser. TMDB_BASE_URL therefore points at the proxy, and callers no
+// longer need a key (getTMDBApiKey returns an empty string for
+// backwards compatibility with existing `api_key=${apiKey}` call sites —
+// the proxy strips/overrides any api_key param).
+export const TMDB_BASE_URL = "/api/tmdb";
 export const TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w500";
 
-export async function getTMDBApiKey() {
-  try {
-    const { key } = await api.get<{ key: string }>("/keys/tmdb");
-    if (!key) {
-      throw new Error("TMDB API key not found in response");
-    }
-    return key;
-  } catch (error) {
-    console.error("Failed to get TMDB API key:", error);
-    throw error;
-  }
+export async function getTMDBApiKey(): Promise<string> {
+  return "";
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -3,6 +3,7 @@ import { createAuth } from "./auth";
 import { streamingRoutes } from "./routes/streaming";
 import { searchRoutes } from "./routes/search";
 import { recommendationRoutes } from "./routes/recommendations";
+import { tmdbProxyRoutes } from "./routes/tmdb";
 import { dataRoutes } from "./routes/data";
 import type { Env } from "./env";
 
@@ -27,13 +28,13 @@ app.get("/api/geo", (c) => {
 // Better Auth: sign-up/sign-in/sign-out/session under /api/auth/*
 app.on(["GET", "POST"], "/api/auth/*", (c) => createAuth(c.env).handler(c.req.raw));
 
-// Same contract as the old get-tmdb-key / get-youtube-key Supabase functions
-app.get("/api/keys/tmdb", (c) => c.json({ key: c.env.TMDB_API_KEY }));
+// Same contract as the old get-youtube-key Supabase function
 app.get("/api/keys/youtube", (c) => c.json({ key: c.env.YOUTUBE_API_KEY || "" }));
 
 app.route("/api", streamingRoutes);
 app.route("/api", searchRoutes);
 app.route("/api", recommendationRoutes);
+app.route("/api", tmdbProxyRoutes);
 app.route("/api", dataRoutes);
 
 // Non-API requests that still reach the Worker fall back to the SPA assets

--- a/worker/lib/streaming.test.ts
+++ b/worker/lib/streaming.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fetchStreamingData, buildResult, type StreamingOption } from "./streaming";
+
+const KEYS = { tmdbApiKey: "test-key" };
+
+/** Minimal Response-like stub for the worker's fetch usage. */
+function res(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function mockFetch(handler: (url: string) => Response | Promise<Response>) {
+  globalThis.fetch = vi.fn((input: any) => Promise.resolve(handler(String(input)))) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildResult", () => {
+  it("separates subscription/free from rent/buy and sorts best-first", () => {
+    const options: StreamingOption[] = [
+      { service: "Apple TV", serviceLogo: "", link: "", type: "rent", quality: "HD" },
+      { service: "Netflix", serviceLogo: "", link: "", type: "subscription", quality: "HD" },
+      { service: "YouTube", serviceLogo: "", link: "", type: "buy", quality: "HD" },
+    ];
+    const r = buildResult(1, "X", options, "tmdb");
+    expect(r.availableServices).toEqual(["Netflix"]);
+    expect(r.rentBuyServices).toEqual(["Apple TV", "YouTube"]);
+    expect(r.hasStreaming).toBe(true);
+    expect(r.streamingOptions[0].type).toBe("subscription"); // sorted best-first
+  });
+
+  it("reports hasStreaming=false when only rent/buy exist", () => {
+    const r = buildResult(1, "X", [
+      { service: "Apple TV", serviceLogo: "", link: "", type: "buy", quality: "HD" },
+    ], "tmdb");
+    expect(r.hasStreaming).toBe(false);
+    expect(r.availableServices).toEqual([]);
+    expect(r.rentBuyServices).toEqual(["Apple TV"]);
+  });
+});
+
+describe("fetchStreamingData — TMDB watch providers", () => {
+  it("parses providers, dedupes plan variants, splits subscription vs rent/buy", async () => {
+    mockFetch((url) =>
+      url.includes("/movie/603")
+        ? res(200, {
+            title: "The Matrix",
+            "watch/providers": {
+              results: {
+                PL: {
+                  flatrate: [
+                    { provider_name: "Netflix", logo_path: "/n.jpg" },
+                    { provider_name: "Netflix Standard with Ads", logo_path: "/n2.jpg" },
+                  ],
+                  rent: [{ provider_name: "Apple TV", logo_path: "/a.jpg" }],
+                  buy: [{ provider_name: "Apple TV", logo_path: "/a.jpg" }],
+                },
+              },
+            },
+          })
+        : res(404, {})
+    );
+
+    const r = await fetchStreamingData(603, "PL", KEYS);
+    expect(r.source).toBe("tmdb");
+    expect(r.hasStreaming).toBe(true);
+    expect(r.availableServices).toEqual(["Netflix"]); // plan variant collapsed
+    expect(r.rentBuyServices).toEqual(["Apple TV"]); // rent+buy collapsed to one
+    expect(r.streamingOptions.filter((o) => o.service === "Netflix")).toHaveLength(1);
+  });
+
+  it("returns a genuine empty (cacheable) when TMDB responds with no region providers", async () => {
+    mockFetch((url) =>
+      url.includes("/movie/603")
+        ? res(200, { title: "X", "watch/providers": { results: { US: { flatrate: [] } } } })
+        : res(404, {})
+    );
+
+    const r = await fetchStreamingData(603, "PL", KEYS);
+    expect(r.source).toBe("none");
+    expect(r.hasStreaming).toBe(false);
+    expect(r.streamingOptions).toEqual([]);
+  });
+
+  it("THROWS (must not cache as empty) when TMDB is unreachable", async () => {
+    mockFetch(() => {
+      throw new Error("network down");
+    });
+    await expect(fetchStreamingData(603, "PL", KEYS)).rejects.toThrow();
+  });
+
+  it("THROWS on TMDB 5xx (transient), so it is retried rather than cached empty", async () => {
+    mockFetch(() => res(503, {}));
+    await expect(fetchStreamingData(603, "PL", KEYS)).rejects.toThrow();
+  });
+
+  it("queries only the TV endpoint when mediaType=tv", async () => {
+    const seen: string[] = [];
+    mockFetch((url) => {
+      seen.push(url);
+      return url.includes("/tv/1399")
+        ? res(200, { name: "GoT", "watch/providers": { results: { PL: { flatrate: [{ provider_name: "HBO Max" }] } } } })
+        : res(404, {});
+    });
+
+    const r = await fetchStreamingData(1399, "PL", KEYS, "tv");
+    expect(r.hasStreaming).toBe(true);
+    expect(r.availableServices).toEqual(["HBO Max"]);
+    expect(seen.every((u) => u.includes("/tv/"))).toBe(true); // never hit /movie/
+  });
+});

--- a/worker/lib/streaming.ts
+++ b/worker/lib/streaming.ts
@@ -141,6 +141,11 @@ const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiK
       ];
 
       const movieTitle = data.title || data.name || data.original_title || data.original_name || '';
+      // TMDB returns a real JustWatch "where to watch" link for the title in
+      // this region. TMDB has NO per-service deep links, so we use this real
+      // aggregator link instead of fabricating per-service URLs (which were
+      // dead/incorrect). Falls back to a service search only if absent.
+      const justWatchLink: string = (watchProviders as { link?: string }).link || '';
       const bestByService = new Map<string, StreamingOption>();
 
       for (const group of providerGroups) {
@@ -154,7 +159,7 @@ const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiK
             serviceLogo: provider.logo_path
               ? `https://image.tmdb.org/t/p/w154${provider.logo_path}`
               : getServiceLogo(serviceName.toLowerCase()),
-            link: getServiceSearchUrl(serviceName.toLowerCase(), movieTitle),
+            link: justWatchLink || getServiceSearchUrl(serviceName.toLowerCase(), movieTitle),
             type: group.type,
             quality: 'HD'
           };

--- a/worker/lib/streaming.ts
+++ b/worker/lib/streaming.ts
@@ -100,14 +100,33 @@ const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiK
   ];
   const endpoints = mediaType ? allEndpoints.filter(e => e.type === mediaType) : allEndpoints;
 
+  // Track whether TMDB actually answered. If no endpoint responds (network
+  // error / 5xx / auth failure) we must NOT report "no providers" — that
+  // would be cached as unavailable. Throwing lets the caller treat it as a
+  // transient error (not cached, retried next time).
+  let respondedOk = false;
+
   for (const endpoint of endpoints) {
+    let response: Response;
     try {
-      const response = await fetch(endpoint.url, {
+      response = await fetch(endpoint.url, {
         headers: { 'Content-Type': 'application/json' }
       });
+    } catch (error) {
+      console.error(`TMDB network error for ${tmdbId} (${endpoint.type}):`, error);
+      continue; // transport failure — leave respondedOk false
+    }
 
-      if (!response.ok) continue;
+    // 404 = this id isn't that media type: a real answer, just not found.
+    if (response.status === 404) { respondedOk = true; continue; }
+    // 401/403/429/5xx = transient/config failure — do not treat as "empty".
+    if (!response.ok) {
+      console.error(`TMDB HTTP ${response.status} for ${tmdbId} (${endpoint.type})`);
+      continue;
+    }
+    respondedOk = true;
 
+    try {
       const data: any = await response.json();
       const watchProviders = data['watch/providers']?.results?.[region];
 
@@ -152,11 +171,14 @@ const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiK
         return buildResult(tmdbId, movieTitle, streamingOptions, 'tmdb');
       }
     } catch (error) {
-      console.error(`TMDB error for ${tmdbId} (${endpoint.type}):`, error);
+      console.error(`TMDB parse error for ${tmdbId} (${endpoint.type}):`, error);
     }
   }
 
-  return null;
+  // Responded but no providers for this region = genuine "not available".
+  if (respondedOk) return null;
+  // Nothing answered = transient failure; signal so it isn't cached as empty.
+  throw new Error(`TMDB unreachable for ${tmdbId}`);
 };
 
 // =====================================================
@@ -259,11 +281,21 @@ export const fetchStreamingData = async (
   keys: { tmdbApiKey: string; rapidApiKey?: string },
   mediaType?: MediaType
 ): Promise<MovieStreamingData> => {
-  const tmdbResult = await fetchTmdbWatchProviders(tmdbId, country, keys.tmdbApiKey, mediaType);
-  if (tmdbResult && tmdbResult.streamingOptions.length > 0) {
-    return tmdbResult;
+  // Primary, authoritative source: TMDB watch providers (JustWatch data).
+  // Throws if TMDB was unreachable; returns null if it responded with no
+  // providers for the region (a genuine "not available").
+  let tmdbResponded = false;
+  try {
+    const tmdbResult = await fetchTmdbWatchProviders(tmdbId, country, keys.tmdbApiKey, mediaType);
+    tmdbResponded = true;
+    if (tmdbResult && tmdbResult.streamingOptions.length > 0) {
+      return tmdbResult;
+    }
+  } catch (error) {
+    console.error(`TMDB failed for ${tmdbId}:`, error);
   }
 
+  // Secondary: RapidAPI can recover (TMDB unreachable) or add coverage.
   if (keys.rapidApiKey) {
     const rapidResult = await fetchRapidApiStreaming(tmdbId, country, keys.rapidApiKey, mediaType);
     if (rapidResult && rapidResult.streamingOptions.length > 0) {
@@ -271,7 +303,13 @@ export const fetchStreamingData = async (
     }
   }
 
-  return buildResult(tmdbId, '', [], 'none');
+  // Only report (and let the route cache) "not available" when the
+  // authoritative source actually answered. Otherwise signal a transient
+  // failure so it is NOT cached as empty and is retried next time.
+  if (tmdbResponded) {
+    return buildResult(tmdbId, '', [], 'none');
+  }
+  throw new Error(`streaming lookup failed for ${tmdbId} (no source responded)`);
 };
 
 // =====================================================

--- a/worker/routes/recommendations.ts
+++ b/worker/routes/recommendations.ts
@@ -3,8 +3,8 @@ import type { Env } from "../env";
 
 // Quiz/preferences-based recommendations via TMDB Discover.
 // Deterministic and reliable (no AI dependency): maps answers/filters to
-// genres + rating + region and returns popular matching titles. Replaces
-// the Supabase get-personalized / get-enhanced recommendation functions.
+// genres + rating + era + region and returns popular matching titles.
+// Supports both movies (/discover/movie) and series (/discover/tv).
 
 export const recommendationRoutes = new Hono<{ Bindings: Env }>();
 
@@ -15,16 +15,20 @@ interface RecoFilters {
   mood?: string;
   region?: string;
   minRating?: number;
+  mediaType?: "movie" | "tv";
+  releaseYearGte?: number;
+  releaseYearLte?: number;
   runtime?: { min?: number; max?: number };
 }
 interface RecoRequest {
   answers?: QuizAnswer[];
   filters?: RecoFilters;
   region?: string;
+  mediaType?: "movie" | "tv";
   maxResults?: number;
 }
 
-const GENRE_NAME_TO_ID: Record<string, number> = {
+const MOVIE_GENRE_TO_ID: Record<string, number> = {
   action: 28, adventure: 12, animation: 16, animacja: 16, comedy: 35, komedia: 35,
   crime: 80, documentary: 99, drama: 18, dramat: 18, family: 10751, fantasy: 14,
   history: 36, horror: 27, music: 10402, mystery: 9648, romance: 10749, romans: 10749,
@@ -32,11 +36,22 @@ const GENRE_NAME_TO_ID: Record<string, number> = {
   akcja: 28,
 };
 
+// TMDB TV genres are coarser; map best-effort.
+const TV_GENRE_TO_ID: Record<string, number> = {
+  action: 10759, adventure: 10759, akcja: 10759, animation: 16, animacja: 16,
+  comedy: 35, komedia: 35, crime: 80, documentary: 99, drama: 18, dramat: 18,
+  family: 10751, kids: 10762, mystery: 9648, "sci-fi": 10765, scifi: 10765,
+  science_fiction: 10765, fantasy: 10765, war: 10768, western: 37,
+  thriller: 9648, horror: 9648, romance: 18, romans: 18,
+};
+
 const GENRE_ID_TO_NAME: Record<number, string> = {
   28: "Action", 12: "Adventure", 16: "Animation", 35: "Comedy", 80: "Crime",
   99: "Documentary", 18: "Drama", 10751: "Family", 14: "Fantasy", 36: "History",
   27: "Horror", 10402: "Music", 9648: "Mystery", 10749: "Romance", 878: "Science Fiction",
-  53: "Thriller", 10752: "War", 37: "Western",
+  53: "Thriller", 10752: "War", 37: "Western", 10759: "Action & Adventure",
+  10762: "Kids", 10763: "News", 10764: "Reality", 10765: "Sci-Fi & Fantasy",
+  10766: "Soap", 10767: "Talk", 10768: "War & Politics",
 };
 
 const MOOD_TO_GENRES: Record<string, string[]> = {
@@ -61,58 +76,89 @@ function toArray(value: string | string[] | undefined): string[] {
   return String(value).split(",").map((s) => s.trim()).filter(Boolean);
 }
 
-function genreId(name: string): number | null {
-  const key = name.toLowerCase().replace("quiz.options.genres.", "").replace(/[^a-z_-]/g, "");
-  return GENRE_NAME_TO_ID[key] ?? null;
+function detectTv(value: string): boolean {
+  const v = value.toLowerCase();
+  return v.includes("series") || v.includes("serial") || v.includes("tv") || v.includes("show");
 }
 
-function buildFilters(body: RecoRequest): Required<Pick<RecoFilters, "genres" | "mood">> & { region: string; minRating: number } {
+interface EffectiveFilters {
+  genres: string[];
+  mood: string;
+  region: string;
+  minRating: number;
+  mediaType: "movie" | "tv";
+  yearGte?: number;
+  yearLte?: number;
+}
+
+function buildFilters(body: RecoRequest): EffectiveFilters {
   const fromAnswers: RecoFilters = {};
+  let mediaType: "movie" | "tv" = body.mediaType || body.filters?.mediaType || "movie";
+
   for (const a of body.answers || []) {
     const id = a.questionId.toLowerCase();
+    const raw = Array.isArray(a.answer) ? a.answer.join(",") : String(a.answer);
     if (id.includes("genre")) fromAnswers.genres = [...(fromAnswers.genres || []), ...toArray(a.answer)];
-    else if (id === "mood" || id.includes("mood") || id === "feeling") fromAnswers.mood = String(a.answer);
+    else if (id === "mood" || id.includes("mood") || id === "feeling") fromAnswers.mood = raw;
     else if (id.includes("platform") || id.includes("streaming")) fromAnswers.platforms = toArray(a.answer);
-    else if (id.includes("region")) fromAnswers.region = String(a.answer);
+    else if (id.includes("region")) fromAnswers.region = raw;
+    else if (id.includes("format") || id.includes("type") || id.includes("content")) {
+      if (detectTv(raw)) mediaType = "tv";
+    }
   }
+
   const f = { ...fromAnswers, ...body.filters };
-  const genres = [...new Set([...(f.genres || [])])];
-  const mood = (f.mood || "").toLowerCase();
-  const region = (body.region || f.region || "US").toUpperCase();
-  const minRating = typeof f.minRating === "number" ? f.minRating : 0;
-  return { genres, mood, region, minRating };
+  return {
+    genres: [...new Set(f.genres || [])],
+    mood: (f.mood || "").toLowerCase(),
+    region: (body.region || f.region || "US").toUpperCase(),
+    minRating: typeof f.minRating === "number" ? f.minRating : 0,
+    mediaType,
+    yearGte: f.releaseYearGte,
+    yearLte: f.releaseYearLte,
+  };
 }
 
 recommendationRoutes.post("/recommendations", async (c) => {
   if (!c.env.TMDB_API_KEY) return c.json({ error: "TMDB not configured" }, 500);
 
   const body = (await c.req.json<RecoRequest>().catch(() => ({}))) as RecoRequest;
-  const { genres, mood, region, minRating } = buildFilters(body);
+  const f = buildFilters(body);
   const maxResults = Math.min(body.maxResults || 12, 30);
+  const isTv = f.mediaType === "tv";
+  const genreMap = isTv ? TV_GENRE_TO_ID : MOVIE_GENRE_TO_ID;
 
-  // Resolve genre ids: explicit genres, then mood-derived, else broad popular set.
-  let genreIds = genres.map(genreId).filter((g): g is number => g != null);
-  if (genreIds.length === 0 && mood && MOOD_TO_GENRES[mood]) {
-    genreIds = MOOD_TO_GENRES[mood].map(genreId).filter((g): g is number => g != null);
+  const resolveGenre = (name: string): number | null => {
+    const key = name.toLowerCase().replace("quiz.options.genres.", "").replace(/[^a-z_&\s-]/g, "").trim();
+    return genreMap[key] ?? null;
+  };
+
+  let genreIds = f.genres.map(resolveGenre).filter((g): g is number => g != null);
+  if (genreIds.length === 0 && f.mood && MOOD_TO_GENRES[f.mood]) {
+    genreIds = MOOD_TO_GENRES[f.mood].map(resolveGenre).filter((g): g is number => g != null);
   }
+  genreIds = [...new Set(genreIds)];
 
-  const lang = REGION_TO_LANG[region] || "en-US";
+  const lang = REGION_TO_LANG[f.region] || "en-US";
+  const dateField = isTv ? "first_air_date" : "primary_release_date";
   const params = new URLSearchParams({
     api_key: c.env.TMDB_API_KEY,
     sort_by: "popularity.desc",
     "vote_count.gte": "100",
     include_adult: "false",
     language: lang,
-    watch_region: region,
+    watch_region: f.region,
     page: "1",
   });
   if (genreIds.length > 0) params.set("with_genres", genreIds.slice(0, 3).join(","));
-  if (minRating > 0) params.set("vote_average.gte", String(minRating));
-  if (body.filters?.runtime?.min) params.set("with_runtime.gte", String(body.filters.runtime.min));
-  if (body.filters?.runtime?.max) params.set("with_runtime.lte", String(body.filters.runtime.max));
+  if (f.minRating > 0) params.set("vote_average.gte", String(f.minRating));
+  if (f.yearGte) params.set(`${dateField}.gte`, `${f.yearGte}-01-01`);
+  if (f.yearLte) params.set(`${dateField}.lte`, `${f.yearLte}-12-31`);
+  if (body.filters?.runtime?.min && !isTv) params.set("with_runtime.gte", String(body.filters.runtime.min));
+  if (body.filters?.runtime?.max && !isTv) params.set("with_runtime.lte", String(body.filters.runtime.max));
 
   try {
-    const res = await fetch(`https://api.themoviedb.org/3/discover/movie?${params}`);
+    const res = await fetch(`https://api.themoviedb.org/3/discover/${isTv ? "tv" : "movie"}?${params}`);
     if (!res.ok) return c.json({ error: "discover failed" }, 502);
     const data = (await res.json()) as { results?: any[] };
 
@@ -121,12 +167,12 @@ recommendationRoutes.post("/recommendations", async (c) => {
       const names = ids.map((id) => GENRE_ID_TO_NAME[id]).filter(Boolean);
       const explanations: string[] = [];
       const matched = names.filter((n) =>
-        genres.some((g) => n.toLowerCase().includes(g.toLowerCase()) || g.toLowerCase().includes(n.toLowerCase()))
+        f.genres.some((g) => n.toLowerCase().includes(g.toLowerCase()) || g.toLowerCase().includes(n.toLowerCase()))
       );
       if (matched.length) explanations.push(`Matches your genre preference: ${matched.join(", ")}`);
       if (m.vote_average >= 8) explanations.push("Critically acclaimed");
       else if (m.vote_average >= 7.5) explanations.push("Highly rated by viewers");
-      if (region !== "US") explanations.push(`Popular in ${region}`);
+      if (f.region !== "US") explanations.push(`Popular in ${f.region}`);
       if (!explanations.length) explanations.push("Popular choice matching your preferences");
 
       return {
@@ -135,12 +181,13 @@ recommendationRoutes.post("/recommendations", async (c) => {
         overview: m.overview || "",
         poster_path: m.poster_path || "",
         backdrop_path: m.backdrop_path || null,
-        release_date: m.release_date || "",
+        release_date: m.release_date || m.first_air_date || "",
         vote_average: m.vote_average ?? 0,
         vote_count: m.vote_count ?? 0,
         popularity: m.popularity ?? 0,
         genre_ids: ids,
         genres: names,
+        media_type: f.mediaType,
         explanations,
       };
     });

--- a/worker/routes/tmdb.ts
+++ b/worker/routes/tmdb.ts
@@ -1,0 +1,48 @@
+import { Hono } from "hono";
+import type { Env } from "../env";
+
+// Transparent TMDB proxy. The browser calls /api/tmdb/<path>?<query> and
+// the Worker injects the API key server-side, so the key never reaches the
+// client. Read-only GET, public (TMDB data isn't user-specific), edge-cached.
+
+export const tmdbProxyRoutes = new Hono<{ Bindings: Env }>();
+
+tmdbProxyRoutes.get("/tmdb/*", async (c) => {
+  if (!c.env.TMDB_API_KEY) return c.json({ error: "TMDB not configured" }, 500);
+
+  const url = new URL(c.req.url);
+  const path = url.pathname.replace(/^\/api\/tmdb\//, "").replace(/^\/+/, "");
+  if (!path || path.includes("..")) return c.json({ error: "invalid path" }, 400);
+
+  // Forward the caller's query params, but force our own api_key.
+  const forward = new URLSearchParams(url.search);
+  forward.delete("api_key");
+  forward.set("api_key", c.env.TMDB_API_KEY);
+
+  // Cache key uses the public URL (no secret in it).
+  const cache = caches.default;
+  const cacheKey = new Request(url.toString());
+  const hit = await cache.match(cacheKey);
+  if (hit) return hit;
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`https://api.themoviedb.org/3/${path}?${forward.toString()}`, {
+      headers: { Accept: "application/json" },
+    });
+  } catch {
+    return c.json({ error: "TMDB unreachable" }, 502);
+  }
+
+  const body = await upstream.text();
+  const response = new Response(body, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": "application/json",
+      // Cache successful responses briefly at the edge.
+      "Cache-Control": upstream.ok ? "public, max-age=300" : "no-store",
+    },
+  });
+  if (upstream.ok) c.executionCtx.waitUntil(cache.put(cacheKey, response.clone()));
+  return response;
+});


### PR DESCRIPTION
Realizacja krytycznych/wysokopriorytetowych punktów z audytu.

## Najpierw najważniejszy kontekst
Audyt opisuje **wciąż wdrożony build stage-1**. Część dużych zarzutów (brak seriali w wyszukiwarce, quiz ze statyczną listą Fight Club/Pulp Fiction) **jest już naprawiona na `main`** — ale nie jest na produkcji, dopóki gałąź produkcyjna Cloudflare nie wskaże `main`. Ten PR dokłada rzeczy, których migracja faktycznie nie obejmowała.

## Zmiany
- **KRYTYCZNE — klucz TMDB nie trafia już do przeglądarki.** Nowy proxy Workera `GET /api/tmdb/*` wstrzykuje klucz po stronie serwera i cache'uje na edge; frontend (`TMDB_BASE_URL`) kieruje tam, `getTMDBApiKey()` zwraca `""`. Usunięty endpoint `/api/keys/tmdb` i dwa zahardkodowane wywołania `api.themoviedb.org` (modal filmu, quiz „comprehensive").
- **Linki do serwisów:** zamiast zmyślania domen z nazwy (martwe/błędne, np. `googleplaymovies.com`) używamy prawdziwego linku agregatora **JustWatch z TMDB** dla tytułu+regionu. (TMDB nie udostępnia deep-linków per-serwis — to jest poprawne, realne źródło.)
- **Rekomendacje — seriale:** format „Serial" → `/discover/tv` (mapowanie gatunków TV + `first_air_date`), wynik z `media_type`. Filmy nadal przez `/discover/movie`.
- **Zakładka Media:** `include_image_language=<lang>,en,null`, żeby dla nie-EN nie była pusta.
- **404:** strona NotFound + trasa catch-all (był czarny ekran).
- **Ulubione:** „polubienie" w quizie faktycznie zapisuje przez API i pokazuje uczciwy komunikat (prośba o logowanie przy 401) zamiast zawsze „dodano do ulubionych".

## Weryfikacja
`tsc` (app + worker), vitest (7/7), `vite build` — zielone. `wrangler dev` potwierdza, że trasy są zamontowane i degradują się łagodnie (to środowisko nie ma egressu, więc realne dane TMDB tylko po wdrożeniu z kluczem).

## Pozostałe punkty audytu (kolejna faza)
Fallback EN dla recenzji, „Twoje platformy" w wynikach quizu = realna dostępność zamiast zaznaczonych serwisów, filtr „Directors", limit roku 2025, suwak oceny „0.0–0.0", logo Hulu, zamykanie modala Escape, spójność językowa UI. Mogę je zrobić w następnej turze.

https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG)_