### PR TITLE
Fix RapidAPI v4 TV endpoint (/shows/tv) so series get streaming data

### DIFF
--- a/worker/lib/streaming.test.ts
+++ b/worker/lib/streaming.test.ts
@@ -114,3 +114,41 @@ describe("fetchStreamingData — TMDB watch providers", () => {
     expect(seen.every((u) => u.includes("/tv/"))).toBe(true); // never hit /movie/
   });
 });
+
+describe("fetchStreamingData — RapidAPI fallback (MovieOfTheNight v4)", () => {
+  it("uses /shows/tv/ (not /shows/series/) and parses streamingOptions for TV", async () => {
+    const seen: string[] = [];
+    mockFetch((url) => {
+      seen.push(url);
+      // TMDB (tv) responds but with no providers in PL -> genuine empty
+      if (url.includes("api.themoviedb.org")) {
+        return res(200, { name: "Show", "watch/providers": { results: { US: {} } } });
+      }
+      // RapidAPI v4 show endpoint
+      if (url.includes("streaming-availability.p.rapidapi.com/shows/tv/1399")) {
+        return res(200, {
+          showType: "series",
+          streamingOptions: {
+            pl: [
+              { service: { id: "netflix", name: "Netflix" }, type: "subscription", link: "https://www.netflix.com/title/1", quality: "hd" },
+              { service: { id: "apple", name: "Apple TV" }, type: "rent", link: "https://tv.apple.com/x", price: { amount: "14.99", currency: "PLN", formatted: "14,99 zł" } },
+            ],
+          },
+        });
+      }
+      return res(404, {});
+    });
+
+    const r = await fetchStreamingData(1399, "PL", { tmdbApiKey: "t", rapidApiKey: "r" }, "tv");
+
+    expect(r.source).toBe("rapidapi");
+    expect(r.hasStreaming).toBe(true);
+    expect(r.availableServices).toEqual(["Netflix"]); // subscription only
+    expect(r.rentBuyServices).toHaveLength(1); // the rent offer goes to rent/buy, not availableServices
+    // The RapidAPI TV call must use /shows/tv/, never the wrong /shows/series/
+    const rapidCalls = seen.filter((u) => u.includes("rapidapi.com"));
+    expect(rapidCalls.some((u) => u.includes("/shows/tv/1399"))).toBe(true);
+    expect(rapidCalls.some((u) => u.includes("/shows/series/"))).toBe(false);
+  });
+});
+

--- a/worker/lib/streaming.ts
+++ b/worker/lib/streaming.ts
@@ -192,9 +192,11 @@ const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiK
 const fetchRapidApiStreaming = async (tmdbId: number, country: string, rapidApiKey: string, mediaType?: MediaType): Promise<MovieStreamingData | null> => {
   if (!rapidApiKey) return null;
 
+  // MovieOfTheNight v4: GET /shows/{type}/{tmdbId}; the TMDB id path uses
+  // "movie" / "tv" (matching TMDB media types), NOT "series".
   const allEndpoints = [
     { url: `https://streaming-availability.p.rapidapi.com/shows/movie/${tmdbId}?country=${country.toLowerCase()}`, type: "movie" as MediaType },
-    { url: `https://streaming-availability.p.rapidapi.com/shows/series/${tmdbId}?country=${country.toLowerCase()}`, type: "tv" as MediaType }
+    { url: `https://streaming-availability.p.rapidapi.com/shows/tv/${tmdbId}?country=${country.toLowerCase()}`, type: "tv" as MediaType }
   ];
   const endpoints = (mediaType ? allEndpoints.filter(e => e.type === mediaType) : allEndpoints).map(e => e.url);
 


### PR DESCRIPTION
## Problem
Drugorzędne źródło dostępności (RapidAPI / MovieOfTheNight) używało `/shows/series/{tmdbId}` — to **nie jest** poprawna ścieżka v4, więc **seriale nigdy nie dostawały danych z RapidAPI**. W v4 ścieżka używa typu mediów z TMDB: `/shows/movie/{id}` i `/shows/tv/{id}`.

## Zmiana
- Endpoint TV: `/shows/series/` → `/shows/tv/`.
- Reszta parsowania (`streamingOptions[country]`, `service.id/name`, `type`, `link`, `price`, `expiresOn`) jest zgodna z v4 — bez zmian.
- Nowy test vitest sprawdza, że fallback RapidAPI parsuje v4 `streamingOptions` i woła `/shows/tv/` (nigdy `/shows/series/`). **8/8 testów przechodzi.**

Kontekst: TMDB pozostaje źródłem głównym (darmowe, autorytatywne, link JustWatch), RapidAPI to uzupełnienie/ratunek z deep-linkami per-serwis — teraz działa też dla seriali.

https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG)_