### PR TITLE
Exact streaming deep links on click, cached in D1 for 7 days

### DIFF
--- a/src/components/movie/EnhancedMovieModal.tsx
+++ b/src/components/movie/EnhancedMovieModal.tsx
@@ -294,6 +294,7 @@ export const EnhancedMovieModal = ({
                         tmdbId={movie.id}
                         title={movieDetails.title}
                         year={movieDetails.release_date?.split("-")[0]}
+                        mediaType={(movie as { media_type?: 'movie' | 'tv' }).media_type}
                       />
                     </div>
                   </div>

--- a/src/components/streaming/StreamingServiceButtons.tsx
+++ b/src/components/streaming/StreamingServiceButtons.tsx
@@ -3,11 +3,13 @@ import { Button } from "@/components/ui/button";
 import { ExternalLink } from "lucide-react";
 import { getUserRegion } from "@/utils/regionDetection";
 import { useStreamingAvailability } from "@/hooks/use-streaming-availability";
+import { resolveServiceDeepLink } from "@/services/streamingAvailabilityPro";
 
 interface StreamingServiceButtonsProps {
   tmdbId: number;
   title?: string;
   year?: string;
+  mediaType?: 'movie' | 'tv';
   className?: string;
 }
 
@@ -51,11 +53,12 @@ const defaultLinks: Record<string, (title: string, year?: string) => string> = {
   'Paramount Plus': (title: string, year?: string) => `https://www.paramountplus.com/search/${encodeURIComponent(title)}`
 };
 
-export const StreamingServiceButtons = ({ 
-  tmdbId, 
-  title = "", 
+export const StreamingServiceButtons = ({
+  tmdbId,
+  title = "",
   year,
-  className = "" 
+  mediaType,
+  className = ""
 }: StreamingServiceButtonsProps) => {
   const [streamingServices, setStreamingServices] = useState<StreamingService[]>([]);
   const [userRegion, setUserRegion] = useState<string>('US');
@@ -122,9 +125,27 @@ export const StreamingServiceButtons = ({
   }, [services, requested, isLoading, title, year]);
 
   const handleServiceClick = (service: StreamingService) => {
-    if (service.link && service.link !== '#') {
-      window.open(service.link, '_blank', 'noopener,noreferrer');
+    const fallback = service.link && service.link !== '#' ? service.link : null;
+    // Open a tab synchronously (preserves the user gesture / avoids popup
+    // blockers), then upgrade it to the exact per-title deep link once
+    // resolved; fall back to the service search link if none is found.
+    const win = window.open('about:blank', '_blank');
+    if (!win) {
+      if (fallback) window.open(fallback, '_blank', 'noopener,noreferrer');
+      return;
     }
+    try { (win as Window).opener = null; } catch { /* ignore */ }
+
+    resolveServiceDeepLink({ tmdbId, country: userRegion, service: service.service, mediaType })
+      .then((deep) => {
+        const target = deep || fallback;
+        if (target) win.location.href = target;
+        else win.close();
+      })
+      .catch(() => {
+        if (fallback) win.location.href = fallback;
+        else win.close();
+      });
   };
 
   const getTypeIcon = (type: string): string => {

--- a/src/services/streamingAvailabilityPro.ts
+++ b/src/services/streamingAvailabilityPro.ts
@@ -89,6 +89,31 @@ export const getUserCountry = (): string => {
   return detectUserRegion().toLowerCase();
 };
 
+/**
+ * Resolve an exact per-title deep link on a streaming service (via the
+ * Worker, which calls RapidAPI and caches in D1 for ~7 days). Returns
+ * null if unavailable — caller should then use its search-link fallback.
+ */
+export async function resolveServiceDeepLink(args: {
+  tmdbId: number;
+  country: string;
+  service: string;
+  mediaType?: 'movie' | 'tv';
+}): Promise<string | null> {
+  try {
+    const q = new URLSearchParams({
+      tmdbId: String(args.tmdbId),
+      country: args.country,
+      service: args.service,
+    });
+    if (args.mediaType) q.set('mediaType', args.mediaType);
+    const res = await api.get<{ link: string | null }>(`/streaming/deeplink?${q.toString()}`);
+    return res.link ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // Get streaming data for multiple movies
 export const getStreamingAvailabilityBatch = async (
   tmdbIds: number[],

--- a/worker/db/schema.ts
+++ b/worker/db/schema.ts
@@ -125,3 +125,17 @@ export const streamingCache = sqliteTable("streaming_cache", {
 }, (table) => [
   primaryKey({ columns: [table.tmdbId, table.country] }),
 ]);
+
+// Per-title deep links to each streaming service, resolved on-click from
+// RapidAPI (MovieOfTheNight) and cached so RapidAPI gets at most ~one
+// request per title per week instead of one per page view.
+export const streamingDeeplinks = sqliteTable("streaming_deeplinks", {
+  tmdbId: integer("tmdb_id").notNull(),
+  country: text("country").notNull(),
+  // JSON: { "<serviceName>": "<deep link url>" }
+  links: text("links").notNull(),
+  cachedAt: integer("cached_at", { mode: "timestamp" }).notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+}, (table) => [
+  primaryKey({ columns: [table.tmdbId, table.country] }),
+]);

--- a/worker/lib/streaming.test.ts
+++ b/worker/lib/streaming.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { fetchStreamingData, buildResult, type StreamingOption } from "./streaming";
+import { fetchStreamingData, buildResult, fetchRapidApiDeepLinks, matchServiceLink, type StreamingOption } from "./streaming";
 
 const KEYS = { tmdbApiKey: "test-key" };
 
@@ -156,3 +156,46 @@ describe("fetchStreamingData — RapidAPI fallback (MovieOfTheNight v4)", () => 
   });
 });
 
+
+describe("matchServiceLink", () => {
+  const links = { Netflix: "https://nf/title", "Amazon Prime Video": "https://amz/title" };
+
+  it("matches exact (case-insensitive)", () => {
+    expect(matchServiceLink(links, "netflix")).toBe("https://nf/title");
+  });
+  it("matches a plan variant by substring", () => {
+    expect(matchServiceLink(links, "Netflix Standard with Ads")).toBe("https://nf/title");
+  });
+  it("returns null when no service matches", () => {
+    expect(matchServiceLink(links, "Disney+")).toBeNull();
+  });
+  it("returns null for empty link maps", () => {
+    expect(matchServiceLink({}, "Netflix")).toBeNull();
+  });
+});
+
+describe("fetchRapidApiDeepLinks", () => {
+  it("returns a service->deeplink map and tries the hinted media type first", async () => {
+    const seen: string[] = [];
+    mockFetch((url) => {
+      seen.push(url);
+      return url.includes("/shows/tv/1399")
+        ? res(200, {
+            streamingOptions: {
+              pl: [{ service: { id: "netflix", name: "Netflix" }, type: "subscription", link: "https://nf/x" }],
+            },
+          })
+        : res(404, {});
+    });
+
+    const map = await fetchRapidApiDeepLinks(1399, "PL", "key", "tv");
+    expect(map["Netflix"]).toBe("https://nf/x");
+    expect(seen[0]).toContain("/shows/tv/"); // hinted type queried first
+  });
+
+  it("returns an empty map when RapidAPI has no data", async () => {
+    mockFetch(() => res(404, {}));
+    const map = await fetchRapidApiDeepLinks(603, "PL", "key", "movie");
+    expect(Object.keys(map)).toHaveLength(0);
+  });
+});

--- a/worker/lib/streaming.ts
+++ b/worker/lib/streaming.ts
@@ -194,7 +194,7 @@ const fetchTmdbWatchProviders = async (tmdbId: number, country: string, tmdbApiK
 // =====================================================
 // SOURCE 2: RapidAPI Streaming Availability (enrichment)
 // =====================================================
-const fetchRapidApiStreaming = async (tmdbId: number, country: string, rapidApiKey: string, mediaType?: MediaType): Promise<MovieStreamingData | null> => {
+export const fetchRapidApiStreaming = async (tmdbId: number, country: string, rapidApiKey: string, mediaType?: MediaType): Promise<MovieStreamingData | null> => {
   if (!rapidApiKey) return null;
 
   // MovieOfTheNight v4: GET /shows/{type}/{tmdbId}; the TMDB id path uses
@@ -323,6 +323,50 @@ export const fetchStreamingData = async (
   }
   throw new Error(`streaming lookup failed for ${tmdbId} (no source responded)`);
 };
+
+// =====================================================
+// Deep links (RapidAPI / MovieOfTheNight) — exact per-title links
+// =====================================================
+
+/** Resolve exact per-service deep links for a title via RapidAPI.
+ *  Tries the hinted media type first, then the other. Returns a map of
+ *  normalized service name -> deep link (empty if none/unavailable). */
+export async function fetchRapidApiDeepLinks(
+  tmdbId: number,
+  country: string,
+  rapidApiKey: string,
+  mediaType?: MediaType
+): Promise<Record<string, string>> {
+  const order: MediaType[] = mediaType
+    ? [mediaType, mediaType === "movie" ? "tv" : "movie"]
+    : ["movie", "tv"];
+
+  for (const type of order) {
+    const data = await fetchRapidApiStreaming(tmdbId, country, rapidApiKey, type).catch(() => null);
+    if (data && data.streamingOptions.length > 0) {
+      const map: Record<string, string> = {};
+      for (const opt of data.streamingOptions) {
+        if (opt.link) map[opt.service] = opt.link;
+      }
+      if (Object.keys(map).length > 0) return map;
+    }
+  }
+  return {};
+}
+
+/** Find the deep link for a service name (exact, then fuzzy). */
+export function matchServiceLink(links: Record<string, string> | null, service: string): string | null {
+  if (!links) return null;
+  const keys = Object.keys(links);
+  const s = service.toLowerCase().trim();
+  const exact = keys.find((k) => k.toLowerCase() === s);
+  if (exact) return links[exact];
+  const fuzzy = keys.find((k) => {
+    const kl = k.toLowerCase();
+    return kl.includes(s) || s.includes(kl);
+  });
+  return fuzzy ? links[fuzzy] : null;
+}
 
 // =====================================================
 // Helper functions

--- a/worker/migrations/0002_streaming_deeplinks.sql
+++ b/worker/migrations/0002_streaming_deeplinks.sql
@@ -1,0 +1,11 @@
+-- Migration number: 0002 	 streaming deep links cache
+-- Per-title deep links resolved from RapidAPI (MovieOfTheNight), cached
+-- ~7 days so we don't hit RapidAPI on every page view.
+CREATE TABLE IF NOT EXISTS streaming_deeplinks (
+  tmdb_id INTEGER NOT NULL,
+  country TEXT NOT NULL,
+  links TEXT NOT NULL,
+  cached_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  PRIMARY KEY (tmdb_id, country)
+);

--- a/worker/routes/streaming.ts
+++ b/worker/routes/streaming.ts
@@ -1,15 +1,71 @@
 import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/d1";
 import { and, eq, gte, inArray, sql } from "drizzle-orm";
-import { streamingCache } from "../db/schema";
-import { fetchStreamingData, buildResult, type MovieStreamingData, type MediaType } from "../lib/streaming";
+import { streamingCache, streamingDeeplinks } from "../db/schema";
+import { fetchStreamingData, buildResult, fetchRapidApiDeepLinks, matchServiceLink, type MovieStreamingData, type MediaType } from "../lib/streaming";
 import type { Env } from "../env";
 
 const CACHE_TTL_HOURS_DATA = 24;
 const CACHE_TTL_HOURS_EMPTY = 6;
 const MAX_BATCH = 50;
 
+const DEEPLINK_TTL_HOURS_DATA = 24 * 7; // 7 days
+const DEEPLINK_TTL_HOURS_EMPTY = 24; // retry next day if nothing found
+
 export const streamingRoutes = new Hono<{ Bindings: Env }>();
+
+// GET /api/streaming/deeplink?tmdbId=&country=&service=[&mediaType=]
+// Resolves an exact per-title deep link on the service via RapidAPI,
+// cached in D1 (~7 days). Returns { link: string | null }; the client
+// falls back to its search link when null.
+streamingRoutes.get("/streaming/deeplink", async (c) => {
+  const tmdbId = parseInt(c.req.query("tmdbId") || "", 10);
+  const country = (c.req.query("country") || "PL").toUpperCase();
+  const service = (c.req.query("service") || "").trim();
+  const mt = c.req.query("mediaType");
+  const mediaType: MediaType | undefined = mt === "tv" ? "tv" : mt === "movie" ? "movie" : undefined;
+
+  if (!Number.isInteger(tmdbId) || tmdbId <= 0 || !service) return c.json({ link: null });
+  if (!c.env.RAPIDAPI_KEY) return c.json({ link: null });
+
+  const db = drizzle(c.env.DB);
+  let links: Record<string, string> | null = null;
+
+  // 1. D1 cache (best-effort; ignore if table not migrated yet)
+  try {
+    const rows = await db
+      .select()
+      .from(streamingDeeplinks)
+      .where(and(
+        eq(streamingDeeplinks.tmdbId, tmdbId),
+        eq(streamingDeeplinks.country, country),
+        gte(streamingDeeplinks.expiresAt, new Date())
+      ));
+    if (rows.length) links = JSON.parse(rows[0].links) as Record<string, string>;
+  } catch (error) {
+    console.error("deeplink cache read failed:", error);
+  }
+
+  // 2. Resolve from RapidAPI on miss, then cache
+  if (!links) {
+    links = await fetchRapidApiDeepLinks(tmdbId, country, c.env.RAPIDAPI_KEY, mediaType).catch(() => ({}));
+    try {
+      const now = Date.now();
+      const ttl = (Object.keys(links).length > 0 ? DEEPLINK_TTL_HOURS_DATA : DEEPLINK_TTL_HOURS_EMPTY) * 60 * 60 * 1000;
+      await db
+        .insert(streamingDeeplinks)
+        .values({ tmdbId, country, links: JSON.stringify(links), cachedAt: new Date(now), expiresAt: new Date(now + ttl) })
+        .onConflictDoUpdate({
+          target: [streamingDeeplinks.tmdbId, streamingDeeplinks.country],
+          set: { links: sql`excluded.links`, cachedAt: sql`excluded.cached_at`, expiresAt: sql`excluded.expires_at` },
+        });
+    } catch (error) {
+      console.error("deeplink cache write failed:", error);
+    }
+  }
+
+  return c.json({ link: matchServiceLink(links, service) });
+});
 
 // POST /api/streaming-availability
 //   { tmdbIds: number[], country?, forceRefresh? }                  (movie heuristic)


### PR DESCRIPTION
## Cel
Przyciski dostępności mają prowadzić **prosto do tytułu u dostawcy** (deep-link z RapidAPI/MovieOfTheNight), bez wysyłania zapytań do RapidAPI przy każdym wyświetleniu strony.

## Jak działa
- Kliknięcie przycisku → Worker `GET /api/streaming/deeplink?tmdbId&country&service[&mediaType]` → `{ link }`.
- Worker sprawdza **cache D1** (`streaming_deeplinks`, 7 dni; 1 dzień gdy brak danych). Przy braku — woła RapidAPI **raz na tytuł** (próbuje wskazanego typu, potem drugiego), zapisuje całą mapę `serwis→link` i zwraca dopasowany link.
- Front otwiera kartę synchronicznie (omija blokadę popupów), po rozwiązaniu podmienia na dokładny deep-link; gdy brak — **fallback do linku-wyszukiwania na serwisie** (czyli i tak ląduje na serwisie, nigdy na TMDB).
- Efekt: RapidAPI dostaje **maks. ~1 zapytanie na tytuł na tydzień** (na kliknięcie, nie na wyświetlenie). TMDB pozostaje źródłem listy dostawców.

## Zmiany
- D1: tabela `streaming_deeplinks` (migracja `0002` + schemat Drizzle). Kod jest odporny, gdy tabela nie jest jeszcze zmigowana (fallback, bez 500).
- Worker lib: `fetchRapidApiDeepLinks` (mapa serwis→link) + `matchServiceLink` (dopasowanie dokładne/rozmyte).
- Front: `resolveServiceDeepLink()` + nowy handler kliknięcia; `mediaType` przekazywany z modala.

## Weryfikacja
`tsc` (app+worker), `vite build`, vitest **14/14** (dodane testy mapy deep-linków i dopasowania serwisu).

## ⚠️ Wymagane po wdrożeniu
Zastosuj migrację `0002` na produkcyjnym D1 — w panelu Cloudflare → D1 → `moviefinder` → Console wklej zawartość `worker/migrations/0002_streaming_deeplinks.sql` i wykonaj. (Do czasu migracji deep-linki działają, tylko bez cache — każde kliknięcie woła RapidAPI.)

https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKr8oHRuQ62rXqG86ZbEWG)_